### PR TITLE
Shared cyber kit: HUD backgrounds, neon cursor, scroll reveals and ScrollHUD rail

### DIFF
--- a/src/Components/cyber/CircuitBG.css
+++ b/src/Components/cyber/CircuitBG.css
@@ -1,0 +1,27 @@
+/* ==================================================================
+   CircuitBG — fixed, non-interactive background canvas layer.
+   Sits behind all content (z-index:0). Never captures pointer, never
+   contributes to layout, never causes overflow.
+   ================================================================== */
+.circuit-bg {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  /* never let the canvas widen the page or intercept input */
+  user-select: none;
+  -webkit-user-select: none;
+  /* purely decorative; keep it from ever driving scroll */
+  contain: strict;
+}
+
+/* Belt-and-braces: if a user has reduced-motion on, the component
+   renders null anyway, but hide any stray canvas just in case. */
+@media (prefers-reduced-motion: reduce) {
+  .circuit-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/CircuitBG.js
+++ b/src/Components/cyber/CircuitBG.js
@@ -1,0 +1,253 @@
+import React, { useEffect, useRef } from "react";
+import "./CircuitBG.css";
+
+/* ------------------------------------------------------------------ */
+/*  CircuitBG — animated circuit / network background layer            */
+/*                                                                     */
+/*  One <canvas> pinned fixed:inset-0, z-index:0, pointer-events:none. */
+/*  Lime/cyan nodes drift and connect into a constellation. The cursor */
+/*  is a live node: nearby points link to it, brighten, and are gently */
+/*  pushed away — so the field reacts to mouse movement. Paused when    */
+/*  the tab is hidden; skipped on reduced-motion / low-end touch.      */
+/* ------------------------------------------------------------------ */
+
+const LIME = [187, 223, 77]; // --lime  #bbdf4d
+const CYAN = [61, 242, 255]; // --cyan  #3df2ff
+
+const TARGET_FPS = 45;
+const FRAME_MS = 1000 / TARGET_FPS;
+const LINK_DIST = 168; // node↔node connect distance (CSS px)
+const LINK_DIST_SQ = LINK_DIST * LINK_DIST;
+const MOUSE_DIST = 240; // node↔cursor connect / influence distance
+const MOUSE_DIST_SQ = MOUSE_DIST * MOUSE_DIST;
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (
+    window.matchMedia("(pointer: coarse)").matches &&
+    window.innerWidth < 768
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/* node count scales with viewport (a bit denser now for prominence) */
+function nodeCountFor(w) {
+  if (w < 640) return 44;
+  if (w < 1024) return 68;
+  return 92;
+}
+
+export default function CircuitBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let nodes = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+
+    // live pointer (CSS px) + a smoothed version so influence feels springy
+    let px = -9999;
+    let py = -9999;
+    let sx = -9999;
+    let sy = -9999;
+    let pointerActive = false;
+
+    const rand = (min, max) => min + Math.random() * (max - min);
+
+    function seedNodes() {
+      const count = nodeCountFor(width);
+      nodes = new Array(count).fill(0).map(() => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: rand(-9, 9),
+        vy: rand(-9, 9),
+        r: rand(0.9, 2.2),
+        color: Math.random() < 0.34 ? CYAN : LIME,
+      }));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.max(1, Math.round(width * dpr));
+      canvas.height = Math.max(1, Math.round(height * dpr));
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seedNodes();
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      // ease the smoothed pointer toward the real one
+      if (pointerActive) {
+        sx += (px - sx) * 0.12;
+        sy += (py - sy) * 0.12;
+      }
+
+      ctx.clearRect(0, 0, width, height);
+
+      // advance nodes; nudge them away from the cursor for reactivity
+      for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        if (pointerActive) {
+          const dx = n.x - sx;
+          const dy = n.y - sy;
+          const dSq = dx * dx + dy * dy;
+          if (dSq < MOUSE_DIST_SQ && dSq > 1) {
+            const d = Math.sqrt(dSq);
+            const push = (1 - d / MOUSE_DIST) * 26; // px/sec, strongest up close
+            n.x += (dx / d) * push * dt;
+            n.y += (dy / d) * push * dt;
+          }
+        }
+        n.x += n.vx * dt;
+        n.y += n.vy * dt;
+        if (n.x < -20) n.x = width + 20;
+        else if (n.x > width + 20) n.x = -20;
+        if (n.y < -20) n.y = height + 20;
+        else if (n.y > height + 20) n.y = -20;
+      }
+
+      // node ↔ node links (brighter than before for prominence)
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dSq = dx * dx + dy * dy;
+          if (dSq > LINK_DIST_SQ) continue;
+          const closeness = 1 - Math.sqrt(dSq) / LINK_DIST;
+          const alpha = closeness * 0.22;
+          if (alpha < 0.006) continue;
+          const c = a.color === CYAN || b.color === CYAN ? CYAN : LIME;
+          ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${alpha})`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+        }
+      }
+
+      // node ↔ cursor links + node highlight near the pointer
+      if (pointerActive) {
+        for (let i = 0; i < nodes.length; i++) {
+          const n = nodes[i];
+          const dx = n.x - sx;
+          const dy = n.y - sy;
+          const dSq = dx * dx + dy * dy;
+          if (dSq > MOUSE_DIST_SQ) continue;
+          const closeness = 1 - Math.sqrt(dSq) / MOUSE_DIST;
+          ctx.strokeStyle = `rgba(${CYAN[0]},${CYAN[1]},${CYAN[2]},${closeness * 0.4})`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(n.x, n.y);
+          ctx.lineTo(sx, sy);
+          ctx.stroke();
+          // brighter dot for influenced nodes
+          ctx.fillStyle = `rgba(${LIME[0]},${LIME[1]},${LIME[2]},${0.25 + closeness * 0.5})`;
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, n.r + closeness * 1.4, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        // soft glow at the cursor
+        const g = ctx.createRadialGradient(sx, sy, 0, sx, sy, 90);
+        g.addColorStop(0, "rgba(61,242,255,0.16)");
+        g.addColorStop(1, "rgba(61,242,255,0)");
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(sx, sy, 90, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // base nodes
+      for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        ctx.fillStyle = `rgba(${n.color[0]},${n.color[1]},${n.color[2]},0.22)`;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    resize();
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    // pointer tracking (window-level; canvas itself is pointer-events:none)
+    function onMove(e) {
+      px = e.clientX;
+      py = e.clientY;
+      if (!pointerActive) {
+        sx = px;
+        sy = py;
+      }
+      pointerActive = true;
+    }
+    function onLeave() {
+      pointerActive = false;
+      px = py = sx = sy = -9999;
+    }
+    window.addEventListener("pointermove", onMove, { passive: true });
+    window.addEventListener("pointerdown", onMove, { passive: true });
+    document.addEventListener("pointerleave", onLeave);
+    window.addEventListener("blur", onLeave);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerdown", onMove);
+      document.removeEventListener("pointerleave", onLeave);
+      window.removeEventListener("blur", onLeave);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="circuit-bg" aria-hidden="true" />;
+}

--- a/src/Components/cyber/CircuitTraceBG.css
+++ b/src/Components/cyber/CircuitTraceBG.css
@@ -1,0 +1,23 @@
+/* ==================================================================
+   CircuitTraceBG — absolute canvas layer, sized to its parent (the
+   hero section), not the viewport. Sits behind the grid/scanline/
+   vignette overlays, purely decorative.
+   ================================================================== */
+.circuit-trace-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  contain: strict;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .circuit-trace-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/CircuitTraceBG.js
+++ b/src/Components/cyber/CircuitTraceBG.js
@@ -1,0 +1,236 @@
+import React, { useEffect, useRef } from "react";
+import "./CircuitTraceBG.css";
+
+/* ------------------------------------------------------------------ */
+/*  CircuitTraceBG — animated PCB trace layer for the Database hero.  */
+/*                                                                     */
+/*  Procedurally generates Manhattan-routed "copper traces" (faint    */
+/*  base lines + square pads at turns/ends), then sends a glowing     */
+/*  signal pulse travelling along each one on a loop — like data      */
+/*  moving through the board. Sized to its parent (the hero section), */
+/*  not the viewport. Paused when tab hidden; skipped on               */
+/*  reduced-motion / low-end touch, same guards as CircuitBG.         */
+/* ------------------------------------------------------------------ */
+
+const LIME = [187, 223, 77]; // --lime
+const CYAN = [61, 242, 255]; // --cyan
+
+const TARGET_FPS = 45;
+const FRAME_MS = 1000 / TARGET_FPS;
+const PAD = 1.6; // half-size of the little square pads, in px
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (window.matchMedia("(pointer: coarse)").matches && window.innerWidth < 768) {
+    return true;
+  }
+  return false;
+}
+
+function traceCountFor(w) {
+  if (w < 640) return 9;
+  if (w < 1024) return 14;
+  return 20;
+}
+
+const rand = (min, max) => min + Math.random() * (max - min);
+
+/* Build one Manhattan-routed polyline: alternating horizontal/vertical
+   segments so it reads as a PCB trace, clamped inside the canvas. */
+function buildTrace(width, height) {
+  const points = [];
+  let x = rand(0, width);
+  let y = rand(0, height);
+  points.push({ x, y });
+
+  const segs = Math.floor(rand(3, 6));
+  let axis = Math.random() < 0.5 ? "x" : "y"; // which axis the next move travels along
+  for (let i = 0; i < segs; i++) {
+    const len = rand(60, 150);
+    const dir = Math.random() < 0.5 ? -1 : 1;
+    if (axis === "x") {
+      x = Math.min(width - 4, Math.max(4, x + dir * len));
+    } else {
+      y = Math.min(height - 4, Math.max(4, y + dir * len));
+    }
+    points.push({ x, y });
+    axis = axis === "x" ? "y" : "x"; // alternate so it actually looks routed
+  }
+
+  // cumulative length lookup table, so a pulse can move at constant speed
+  let total = 0;
+  const cum = [0];
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x;
+    const dy = points[i].y - points[i - 1].y;
+    total += Math.hypot(dx, dy);
+    cum.push(total);
+  }
+
+  return {
+    points,
+    cum,
+    total: Math.max(total, 1),
+    color: Math.random() < 0.32 ? CYAN : LIME,
+    speed: rand(70, 150), // px / sec
+    t: Math.random(), // 0..1 progress, randomized so pulses don't sync up
+  };
+}
+
+/* Given progress t (0..1) along a trace, return the {x,y} on its polyline. */
+function pointAt(trace, t) {
+  const target = t * trace.total;
+  const { points, cum } = trace;
+  let i = 1;
+  while (i < cum.length && cum[i] < target) i++;
+  if (i >= points.length) i = points.length - 1;
+  const segStart = cum[i - 1];
+  const segLen = cum[i] - segStart || 1;
+  const local = (target - segStart) / segLen;
+  const a = points[i - 1];
+  const b = points[i];
+  return { x: a.x + (b.x - a.x) * local, y: a.y + (b.y - a.y) * local };
+}
+
+export default function CircuitTraceBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    const parent = canvas && canvas.parentElement;
+    if (!canvas || !parent) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let traces = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+
+    function seed() {
+      const count = traceCountFor(width);
+      traces = new Array(count).fill(0).map(() => buildTrace(width, height));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const r = parent.getBoundingClientRect();
+      width = Math.max(1, Math.round(r.width));
+      height = Math.max(1, Math.round(r.height));
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seed();
+    }
+
+    function drawBaseTraces() {
+      for (const tr of traces) {
+        ctx.strokeStyle = `rgba(${tr.color[0]},${tr.color[1]},${tr.color[2]},0.14)`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(tr.points[0].x, tr.points[0].y);
+        for (let i = 1; i < tr.points.length; i++) {
+          ctx.lineTo(tr.points[i].x, tr.points[i].y);
+        }
+        ctx.stroke();
+
+        // square pads at every joint (PCB via/pad look)
+        ctx.fillStyle = `rgba(${tr.color[0]},${tr.color[1]},${tr.color[2]},0.22)`;
+        for (const p of tr.points) {
+          ctx.fillRect(p.x - PAD, p.y - PAD, PAD * 2, PAD * 2);
+        }
+      }
+    }
+
+    function drawPulses() {
+      const TAIL = 8; // comet-tail sample count
+      for (const tr of traces) {
+        for (let k = 0; k < TAIL; k++) {
+          const tt = tr.t - k * 0.014;
+          const wrapped = ((tt % 1) + 1) % 1;
+          const { x, y } = pointAt(tr, wrapped);
+          const fade = 1 - k / TAIL;
+          const alpha = fade * 0.85;
+          const r = 2.6 * fade + 0.4;
+          ctx.fillStyle = `rgba(${tr.color[0]},${tr.color[1]},${tr.color[2]},${alpha})`;
+          ctx.beginPath();
+          ctx.arc(x, y, r, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        // soft glow at the pulse head
+        const head = pointAt(tr, tr.t);
+        const g = ctx.createRadialGradient(head.x, head.y, 0, head.x, head.y, 16);
+        g.addColorStop(0, `rgba(${tr.color[0]},${tr.color[1]},${tr.color[2]},0.35)`);
+        g.addColorStop(1, `rgba(${tr.color[0]},${tr.color[1]},${tr.color[2]},0)`);
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(head.x, head.y, 16, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      ctx.clearRect(0, 0, width, height);
+
+      for (const tr of traces) {
+        tr.t = (tr.t + (tr.speed / tr.total) * dt) % 1;
+      }
+
+      drawBaseTraces();
+      drawPulses();
+    }
+
+    resize();
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    const ro = "ResizeObserver" in window ? new ResizeObserver(() => resize()) : null;
+    if (ro) ro.observe(parent);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      if (ro) ro.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="circuit-trace-bg" aria-hidden="true" />;
+}

--- a/src/Components/cyber/Cursor.css
+++ b/src/Components/cyber/Cursor.css
@@ -1,0 +1,114 @@
+/* ==================================================================
+   NEURAL_BUILD // OS — custom neon cursor + magnetic wrapper
+   Two fixed layers: a lime DOT that pins to the pointer and a cyan
+   RING that lags via rAF lerp. Compositor-only (transform/opacity).
+   ================================================================== */
+
+/* Hide the native cursor ONLY while the custom one is live (fine pointer).
+   Scoped by .has-cursor so touch / coarse devices keep their real cursor. */
+.has-cursor,
+.has-cursor * {
+  cursor: none !important;
+}
+
+/* Shared layer chrome */
+.cur-dot,
+.cur-ring {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 99999;
+  pointer-events: none;
+  opacity: 0;
+  /* transform is written inline every frame; only fade opacity here */
+  transition: opacity var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+  will-change: transform, opacity;
+  /* start centered on our own origin so translate(-50%,-50%) lands true */
+  transform: translate3d(-100px, -100px, 0) translate(-50%, -50%);
+}
+
+/* fade in once the pointer has produced a real position */
+.cur-dot.cur--on,
+.cur-ring.cur--on {
+  opacity: 1;
+}
+
+/* ---- the DOT: small, lime, pinned exactly to the pointer ---- */
+.cur-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--lime, #bbdf4d);
+  box-shadow: var(--glow-lime-sm, 0 0 12px rgba(187, 223, 77, 0.45));
+}
+
+/* ---- the RING: larger, cyan, lags behind via lerp ---- */
+.cur-ring {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1.5px solid var(--cyan, #3df2ff);
+  box-shadow: var(--glow-cyan-sm, 0 0 12px rgba(61, 242, 255, 0.6));
+  /* animate size/color independently of the per-frame transform */
+  transition:
+    opacity var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    width var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    height var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    border-color var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    background-color var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1)),
+    box-shadow var(--dur-2, 200ms) var(--ease-out, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+/* over an interactive element: bloom ~1.8x + invert to lime */
+.cur-ring--active {
+  width: 68px;
+  height: 68px;
+  border-color: var(--lime, #bbdf4d);
+  background: rgba(187, 223, 77, 0.1);
+  box-shadow: var(--glow-lime-md, 0 0 22px rgba(187, 223, 77, 0.45));
+}
+
+/* subtle press feedback */
+.cur-ring--down {
+  width: 26px;
+  height: 26px;
+}
+.cur-ring--active.cur-ring--down {
+  width: 58px;
+  height: 58px;
+}
+
+/* ================================================================== */
+/*  Magnetic wrapper                                                  */
+/* ================================================================== */
+
+/* Inline element that must not disturb the layout of its child link/button.
+   No transition here — easing is driven per-frame by rAF in JS. */
+.mag {
+  display: inline-block;
+}
+.mag--live {
+  will-change: transform;
+}
+
+/* ================================================================== */
+/*  Reduced motion — keep the cursor, drop the easing/press flourish  */
+/* ================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  /* fade only — no eased size/color/transform on the ring */
+  .cur-dot,
+  .cur-ring {
+    transition: opacity var(--dur-1, 150ms) linear;
+  }
+  /* keep the hover bloom (it aids affordance) but drop the press-scale jump */
+  .cur-ring--down {
+    width: 38px;
+    height: 38px;
+  }
+  .cur-ring--active,
+  .cur-ring--active.cur-ring--down {
+    width: 68px;
+    height: 68px;
+  }
+}

--- a/src/Components/cyber/Cursor.js
+++ b/src/Components/cyber/Cursor.js
@@ -1,0 +1,309 @@
+import React, { useEffect, useRef, useState } from "react";
+import "./Cursor.css";
+
+/* ------------------------------------------------------------------ */
+/*  Shared pointer-capability helpers                                 */
+/* ------------------------------------------------------------------ */
+
+/* We only ever run the heavy cursor / magnetism on a genuine fine, hovering
+   pointer (mouse / trackpad). Touch + stylus stay untouched. */
+const FINE_QUERY = "(pointer: fine)";
+const HOVER_QUERY = "(hover: hover)";
+
+function supportsFinePointer() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return (
+    window.matchMedia(FINE_QUERY).matches &&
+    window.matchMedia(HOVER_QUERY).matches
+  );
+}
+
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/* Elements that should make the ring bloom + invert to lime. */
+const INTERACTIVE_SELECTOR =
+  "a, button, .ch-btn, .nvx__link, .nvx__burger, [data-cursor]";
+
+/* ================================================================== */
+/*  <Cursor /> — neon dot + lagging ring                              */
+/* ================================================================== */
+
+export default function Cursor() {
+  // Re-checked on mount so SSR / first paint never assumes a fine pointer.
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(supportsFinePointer());
+  }, []);
+
+  if (!enabled) return null;
+  return <CursorLayer />;
+}
+
+/* The actual DOM + rAF loop, mounted only once we KNOW it's a fine pointer. */
+function CursorLayer() {
+  const dotRef = useRef(null);
+  const ringRef = useRef(null);
+
+  useEffect(() => {
+    const dot = dotRef.current;
+    const ring = ringRef.current;
+    if (!dot || !ring) return;
+
+    const reduce = prefersReducedMotion();
+    const root = document.documentElement;
+    root.classList.add("has-cursor");
+
+    // Live pointer target + eased ring position.
+    let tx = window.innerWidth / 2;
+    let ty = window.innerHeight / 2;
+    let rx = tx;
+    let ry = ty;
+    let visible = false;
+    let hovering = false;
+    let rafId = 0;
+    let running = false;
+    let paused = false;
+
+    const setActive = (on) => {
+      if (on === hovering) return;
+      hovering = on;
+      ring.classList.toggle("cur-ring--active", on);
+    };
+
+    const onMove = (e) => {
+      tx = e.clientX;
+      ty = e.clientY;
+      if (!visible) {
+        visible = true;
+        // Snap the ring to the pointer the first time so it doesn't fly in.
+        rx = tx;
+        ry = ty;
+        dot.classList.add("cur--on");
+        ring.classList.add("cur--on");
+      }
+      // Dot tracks the pointer exactly, every move — no lerp.
+      dot.style.transform = `translate3d(${tx}px, ${ty}px, 0) translate(-50%, -50%)`;
+
+      // Hover state via the element actually under the pointer. Using the
+      // event target (rather than a separate elementFromPoint call) keeps this
+      // cheap and correct for nested children of interactive elements.
+      const el = e.target;
+      setActive(!!(el && el.closest && el.closest(INTERACTIVE_SELECTOR)));
+
+      if (reduce) {
+        // No easing when reduced motion is requested — ring pins to the dot.
+        rx = tx;
+        ry = ty;
+        ring.style.transform = `translate3d(${rx}px, ${ry}px, 0) translate(-50%, -50%)`;
+      } else {
+        // Wake the easing loop so the ring catches up to the new target.
+        start();
+      }
+    };
+
+    const onDown = () => ring.classList.add("cur-ring--down");
+    const onUp = () => ring.classList.remove("cur-ring--down");
+
+    const onLeave = () => {
+      visible = false;
+      dot.classList.remove("cur--on");
+      ring.classList.remove("cur--on");
+    };
+    const onEnter = () => {
+      // Re-show on re-entry; onMove will flip `visible` back on.
+    };
+
+    // Ring easing loop — compositor-only transform, rAF-throttled. Settles and
+    // stops once the ring has caught up so it doesn't burn a frame forever.
+    const tick = () => {
+      rx += (tx - rx) * 0.18;
+      ry += (ty - ry) * 0.18;
+      ring.style.transform = `translate3d(${rx}px, ${ry}px, 0) translate(-50%, -50%)`;
+      if (Math.abs(tx - rx) < 0.1 && Math.abs(ty - ry) < 0.1) {
+        rx = tx;
+        ry = ty;
+        ring.style.transform = `translate3d(${rx}px, ${ry}px, 0) translate(-50%, -50%)`;
+        running = false;
+        rafId = 0;
+        return;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+
+    // No-op if the loop is already running or motion is suppressed/paused.
+    const start = () => {
+      if (running || reduce || paused) return;
+      running = true;
+      rafId = requestAnimationFrame(tick);
+    };
+
+    const stop = () => {
+      running = false;
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
+    };
+
+    // Pause the loop when the tab is hidden or the window loses focus; resume
+    // (and snap the ring to the pointer target) when it comes back.
+    const onVisibility = () => {
+      if (document.hidden) {
+        paused = true;
+        stop();
+      } else {
+        paused = false;
+        start();
+      }
+    };
+    const onWindowBlur = () => {
+      paused = true;
+      stop();
+      onLeave();
+    };
+    const onWindowFocus = () => {
+      paused = false;
+      start();
+    };
+
+    window.addEventListener("pointermove", onMove, { passive: true });
+    window.addEventListener("pointerdown", onDown, { passive: true });
+    window.addEventListener("pointerup", onUp, { passive: true });
+    document.addEventListener("mouseleave", onLeave);
+    document.addEventListener("mouseenter", onEnter);
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("blur", onWindowBlur);
+    window.addEventListener("focus", onWindowFocus);
+
+    return () => {
+      stop();
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("pointerup", onUp);
+      document.removeEventListener("mouseleave", onLeave);
+      document.removeEventListener("mouseenter", onEnter);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("blur", onWindowBlur);
+      window.removeEventListener("focus", onWindowFocus);
+      root.classList.remove("has-cursor");
+    };
+  }, []);
+
+  return (
+    <>
+      <div ref={ringRef} className="cur-ring" aria-hidden="true" />
+      <div ref={dotRef} className="cur-dot" aria-hidden="true" />
+    </>
+  );
+}
+
+/* ================================================================== */
+/*  <Magnetic /> — wraps a target so it drifts toward the pointer     */
+/* ================================================================== */
+
+export function Magnetic({
+  children,
+  className = "",
+  strength = 0.35,
+  radius = 90,
+}) {
+  const ref = useRef(null);
+  const frame = useRef(0);
+  const pos = useRef({ x: 0, y: 0 }); // current (eased) offset
+  const target = useRef({ x: 0, y: 0 }); // desired offset
+  const [enabled, setEnabled] = useState(false);
+
+  // Decide capability on mount (client only). Coarse / no-hover => inert span.
+  useEffect(() => {
+    setEnabled(supportsFinePointer());
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const reduce = prefersReducedMotion();
+    let running = false;
+
+    const apply = () => {
+      el.style.transform = `translate3d(${pos.current.x}px, ${pos.current.y}px, 0)`;
+    };
+
+    const loop = () => {
+      // Ease current toward target; stop the loop once effectively settled.
+      const ease = reduce ? 1 : 0.2;
+      pos.current.x += (target.current.x - pos.current.x) * ease;
+      pos.current.y += (target.current.y - pos.current.y) * ease;
+      apply();
+      const dx = Math.abs(target.current.x - pos.current.x);
+      const dy = Math.abs(target.current.y - pos.current.y);
+      if (dx < 0.1 && dy < 0.1) {
+        pos.current.x = target.current.x;
+        pos.current.y = target.current.y;
+        apply();
+        running = false;
+        frame.current = 0;
+        return;
+      }
+      frame.current = requestAnimationFrame(loop);
+    };
+
+    const start = () => {
+      if (running) return;
+      running = true;
+      frame.current = requestAnimationFrame(loop);
+    };
+
+    const onMove = (e) => {
+      const r = el.getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      const cy = r.top + r.height / 2;
+      const dx = e.clientX - cx;
+      const dy = e.clientY - cy;
+      const dist = Math.hypot(dx, dy);
+      if (dist > radius) {
+        target.current.x = 0;
+        target.current.y = 0;
+      } else {
+        // Falloff so the pull is gentlest at the rim, strongest near center.
+        const falloff = 1 - dist / radius;
+        target.current.x = dx * strength * falloff;
+        target.current.y = dy * strength * falloff;
+      }
+      start();
+    };
+
+    const onLeave = () => {
+      target.current.x = 0;
+      target.current.y = 0;
+      start();
+    };
+
+    el.addEventListener("pointermove", onMove);
+    el.addEventListener("pointerleave", onLeave);
+
+    return () => {
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerleave", onLeave);
+      if (frame.current) cancelAnimationFrame(frame.current);
+      // Reset any lingering transform so unmount/remount is clean.
+      el.style.transform = "";
+    };
+  }, [enabled, strength, radius]);
+
+  // Coarse / no-hover pointers: plain inert span, zero handlers.
+  if (!enabled) {
+    return <span className={`mag ${className}`.trim()}>{children}</span>;
+  }
+
+  return (
+    <span ref={ref} className={`mag mag--live ${className}`.trim()}>
+      {children}
+    </span>
+  );
+}

--- a/src/Components/cyber/HoloGridBG.css
+++ b/src/Components/cyber/HoloGridBG.css
@@ -1,0 +1,18 @@
+.holo-grid-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  contain: strict;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .holo-grid-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/HoloGridBG.js
+++ b/src/Components/cyber/HoloGridBG.js
@@ -1,0 +1,250 @@
+import React, { useEffect, useRef } from "react";
+import "./HoloGridBG.css";
+
+/* ==================================================================
+   HoloGridBG — Tron-style perspective floor grid + floating rotating
+   wireframe polyhedra (cubes / tetrahedra), for the Projects hero.
+   Reads as "holographic archive vault" rather than a flat photo.
+   Sized to its parent, same conventions as the other cyber canvases.
+   ================================================================== */
+
+const LIME = [187, 223, 77];
+const CYAN = [61, 242, 255];
+
+const TARGET_FPS = 45;
+const FRAME_MS = 1000 / TARGET_FPS;
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (window.matchMedia("(pointer: coarse)").matches && window.innerWidth < 768) {
+    return true;
+  }
+  return false;
+}
+
+const rand = (min, max) => min + Math.random() * (max - min);
+
+/* ---- simple wireframe solids, unit-scaled ---- */
+const CUBE_VERTS = [
+  [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+  [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1],
+];
+const CUBE_EDGES = [
+  [0, 1], [1, 2], [2, 3], [3, 0],
+  [4, 5], [5, 6], [6, 7], [7, 4],
+  [0, 4], [1, 5], [2, 6], [3, 7],
+];
+const TETRA_VERTS = [
+  [1, 1, 1], [1, -1, -1], [-1, 1, -1], [-1, -1, 1],
+];
+const TETRA_EDGES = [
+  [0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3],
+];
+
+function buildShape(width, height) {
+  const isCube = Math.random() < 0.55;
+  return {
+    verts: isCube ? CUBE_VERTS : TETRA_VERTS,
+    edges: isCube ? CUBE_EDGES : TETRA_EDGES,
+    x: rand(width * 0.1, width * 0.9),
+    y: rand(height * 0.15, height * 1.05),
+    size: rand(20, 42),
+    speedY: rand(8, 18),
+    rx: rand(0, Math.PI * 2),
+    ry: rand(0, Math.PI * 2),
+    vrx: rand(-0.3, 0.3),
+    vry: rand(0.15, 0.45),
+    color: Math.random() < 0.4 ? CYAN : LIME,
+  };
+}
+
+export default function HoloGridBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    const parent = canvas && canvas.parentElement;
+    if (!canvas || !parent) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let horizonY = 0;
+    let gridOffset = 0;
+    let shapes = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+
+    function seedShapes() {
+      const count = width < 640 ? 4 : width < 1100 ? 6 : 8;
+      shapes = new Array(count).fill(0).map(() => buildShape(width, height));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const r = parent.getBoundingClientRect();
+      width = Math.max(1, Math.round(r.width));
+      height = Math.max(1, Math.round(r.height));
+      horizonY = height * 0.32;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seedShapes();
+    }
+
+    function drawFloor() {
+      const cx = width / 2;
+      const floorH = height - horizonY;
+
+      // converging verticals
+      ctx.strokeStyle = "rgba(61,242,255,0.14)";
+      ctx.lineWidth = 1;
+      const cols = 9;
+      for (let i = -cols; i <= cols; i++) {
+        const bottomX = cx + i * (width / (cols * 1.15));
+        ctx.beginPath();
+        ctx.moveTo(cx, horizonY);
+        ctx.lineTo(bottomX, height);
+        ctx.stroke();
+      }
+
+      // flowing horizontals, compressed near the horizon
+      const N = 16;
+      ctx.strokeStyle = "rgba(187,223,77,0.16)";
+      for (let i = 0; i < N; i++) {
+        const t = ((i / N + gridOffset) % 1 + 1) % 1;
+        const eased = Math.pow(t, 2.1);
+        const y = horizonY + eased * floorH;
+        const alpha = 0.05 + eased * 0.22;
+        ctx.strokeStyle = `rgba(187,223,77,${alpha})`;
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(width, y);
+        ctx.stroke();
+      }
+
+      // horizon glow line
+      const g = ctx.createLinearGradient(0, horizonY - 1, 0, horizonY + 1);
+      g.addColorStop(0, "rgba(61,242,255,0)");
+      g.addColorStop(0.5, "rgba(61,242,255,0.5)");
+      g.addColorStop(1, "rgba(61,242,255,0)");
+      ctx.strokeStyle = g;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(0, horizonY);
+      ctx.lineTo(width, horizonY);
+      ctx.stroke();
+    }
+
+    function project(v, rx, ry, ox, oy, size) {
+      let [x, y, z] = v;
+      // rotate Y
+      const cy_ = Math.cos(ry), sy_ = Math.sin(ry);
+      const x1 = x * cy_ + z * sy_;
+      const z1 = -x * sy_ + z * cy_;
+      // rotate X
+      const cx_ = Math.cos(rx), sx_ = Math.sin(rx);
+      const y1 = y * cx_ - z1 * sx_;
+      const z2 = y * sx_ + z1 * cx_;
+
+      const focal = 4;
+      const scale = focal / (focal + z2);
+      return {
+        x: ox + x1 * scale * size,
+        y: oy + y1 * scale * size,
+        scale,
+      };
+    }
+
+    function drawShapes(dt) {
+      for (const s of shapes) {
+        s.rx += s.vrx * dt;
+        s.ry += s.vry * dt;
+        s.y -= s.speedY * dt;
+        if (s.y < -60) {
+          Object.assign(s, buildShape(width, height));
+          s.y = height + rand(0, 60);
+        }
+
+        const pts = s.verts.map((v) => project(v, s.rx, s.ry, s.x, s.y, s.size));
+        const depthFade = Math.max(0.25, Math.min(1, s.y / height));
+        ctx.strokeStyle = `rgba(${s.color[0]},${s.color[1]},${s.color[2]},${0.55 * depthFade})`;
+        ctx.lineWidth = 1.2;
+        for (const [a, b] of s.edges) {
+          ctx.beginPath();
+          ctx.moveTo(pts[a].x, pts[a].y);
+          ctx.lineTo(pts[b].x, pts[b].y);
+          ctx.stroke();
+        }
+        // vertex glints
+        ctx.fillStyle = `rgba(${s.color[0]},${s.color[1]},${s.color[2]},${0.8 * depthFade})`;
+        for (const p of pts) {
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 1.4, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      ctx.clearRect(0, 0, width, height);
+      gridOffset = (gridOffset + dt * 0.09) % 1;
+
+      drawFloor();
+      drawShapes(dt);
+    }
+
+    resize();
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    const ro = "ResizeObserver" in window ? new ResizeObserver(() => resize()) : null;
+    if (ro) ro.observe(parent);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      if (ro) ro.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="holo-grid-bg" aria-hidden="true" />;
+}

--- a/src/Components/cyber/PartsBG.css
+++ b/src/Components/cyber/PartsBG.css
@@ -1,0 +1,18 @@
+.parts-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  contain: strict;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .parts-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/PartsBG.js
+++ b/src/Components/cyber/PartsBG.js
@@ -1,0 +1,231 @@
+import React, { useEffect, useRef } from "react";
+import "./PartsBG.css";
+
+/* ==================================================================
+   PartsBG — actual electronic-component schematic symbols (resistor,
+   capacitor, IC chip, LED/diode, microcontroller board) drifting like
+   parts in a zero-g inventory bay, for the Components hero. Each is
+   drawn as a line-art stamp in local space, then translated/rotated/
+   scaled per floating instance. Sized to its parent, same conventions
+   as the other cyber canvases.
+   ================================================================== */
+
+const LIME = "187,223,77";
+const CYAN = "61,242,255";
+
+const TARGET_FPS = 40;
+const FRAME_MS = 1000 / TARGET_FPS;
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (window.matchMedia("(pointer: coarse)").matches && window.innerWidth < 768) {
+    return true;
+  }
+  return false;
+}
+
+const rand = (min, max) => min + Math.random() * (max - min);
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+/* ---- schematic-symbol stamps, drawn centered at the origin ---- */
+function drawResistor(ctx) {
+  const pts = [
+    [-50, 0], [-30, 0], [-22, -16], [-14, 16], [-6, -16],
+    [2, 16], [10, -16], [18, 16], [26, 0], [50, 0],
+  ];
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+  ctx.stroke();
+}
+
+function drawCapacitor(ctx) {
+  ctx.beginPath();
+  ctx.moveTo(-50, 0); ctx.lineTo(-7, 0);
+  ctx.moveTo(7, 0); ctx.lineTo(50, 0);
+  ctx.moveTo(-7, -20); ctx.lineTo(-7, 20);
+  ctx.moveTo(7, -20); ctx.lineTo(7, 20);
+  ctx.stroke();
+}
+
+function drawIC(ctx) {
+  ctx.strokeRect(-40, -22, 80, 44);
+  ctx.beginPath();
+  ctx.arc(0, -22, 7, Math.PI, 0);
+  ctx.stroke();
+  for (let i = 0; i < 4; i++) {
+    const x = -30 + i * 20;
+    ctx.beginPath();
+    ctx.moveTo(x, -22); ctx.lineTo(x, -32);
+    ctx.moveTo(x, 22); ctx.lineTo(x, 32);
+    ctx.stroke();
+  }
+}
+
+function drawDiode(ctx, led) {
+  ctx.beginPath();
+  ctx.moveTo(-50, 0); ctx.lineTo(-11, 0);
+  ctx.moveTo(11, 0); ctx.lineTo(50, 0);
+  ctx.moveTo(-11, -15); ctx.lineTo(-11, 15); ctx.lineTo(11, 0); ctx.closePath();
+  ctx.moveTo(11, -15); ctx.lineTo(11, 15);
+  ctx.stroke();
+  if (led) {
+    ctx.beginPath();
+    ctx.moveTo(16, -20); ctx.lineTo(26, -30);
+    ctx.moveTo(23, -30); ctx.lineTo(26, -30); ctx.lineTo(26, -27);
+    ctx.moveTo(26, -12); ctx.lineTo(36, -22);
+    ctx.moveTo(33, -22); ctx.lineTo(36, -22); ctx.lineTo(36, -19);
+    ctx.stroke();
+  }
+}
+
+function drawBoard(ctx) {
+  ctx.strokeRect(-55, -35, 110, 70);
+  ctx.strokeRect(-55, -27, 18, 16);
+  for (let i = 0; i < 8; i++) {
+    ctx.beginPath();
+    ctx.arc(-45 + i * 13, 28, 2, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.beginPath();
+  ctx.arc(40, -20, 6, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.strokeRect(-10, -10, 30, 20);
+}
+
+const STAMPS = [
+  { draw: drawResistor, w: 100 },
+  { draw: drawCapacitor, w: 100 },
+  { draw: drawIC, w: 90 },
+  { draw: (ctx) => drawDiode(ctx, false), w: 100 },
+  { draw: (ctx) => drawDiode(ctx, true), w: 100 },
+  { draw: drawBoard, w: 120 },
+];
+
+function buildPart(width, height) {
+  const stamp = pick(STAMPS);
+  return {
+    stamp,
+    x: rand(0, width),
+    y: rand(0, height),
+    vx: rand(-10, 10),
+    vy: rand(-7, 7),
+    rot: rand(0, Math.PI * 2),
+    vr: rand(-0.25, 0.25),
+    scale: rand(0.32, 0.62),
+    color: Math.random() < 0.32 ? CYAN : LIME,
+    alpha: rand(0.35, 0.75),
+  };
+}
+
+export default function PartsBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    const parent = canvas && canvas.parentElement;
+    if (!canvas || !parent) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let parts = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+
+    function seedParts() {
+      const count = width < 640 ? 6 : width < 1100 ? 9 : 13;
+      parts = new Array(count).fill(0).map(() => buildPart(width, height));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const r = parent.getBoundingClientRect();
+      width = Math.max(1, Math.round(r.width));
+      height = Math.max(1, Math.round(r.height));
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seedParts();
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      ctx.clearRect(0, 0, width, height);
+
+      const margin = 80;
+      for (const p of parts) {
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.rot += p.vr * dt;
+
+        if (p.x < -margin) p.x = width + margin;
+        if (p.x > width + margin) p.x = -margin;
+        if (p.y < -margin) p.y = height + margin;
+        if (p.y > height + margin) p.y = -margin;
+
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rot);
+        ctx.scale(p.scale, p.scale);
+        ctx.strokeStyle = `rgba(${p.color},${p.alpha})`;
+        ctx.lineWidth = 1.6 / p.scale;
+        ctx.lineJoin = "round";
+        p.stamp.draw(ctx);
+        ctx.restore();
+      }
+    }
+
+    resize();
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    const ro = "ResizeObserver" in window ? new ResizeObserver(() => resize()) : null;
+    if (ro) ro.observe(parent);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      if (ro) ro.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="parts-bg" aria-hidden="true" />;
+}

--- a/src/Components/cyber/RadarBG.css
+++ b/src/Components/cyber/RadarBG.css
@@ -1,0 +1,18 @@
+.radar-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  contain: strict;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radar-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/RadarBG.js
+++ b/src/Components/cyber/RadarBG.js
@@ -1,0 +1,240 @@
+import React, { useEffect, useRef } from "react";
+import "./RadarBG.css";
+
+/* ==================================================================
+   RadarBG — animated target-lock / radar sweep, for the Challenge
+   hero. A rotating sweep beam circles a set of static rings +
+   crosshair; blips flash awake as the sweep passes their angle,
+   like a signal being detected. Sized to its parent, not the
+   viewport — same conventions as CircuitTraceBG.
+   ================================================================== */
+
+const LIME = [187, 223, 77];
+const CYAN = [61, 242, 255];
+
+const TARGET_FPS = 45;
+const FRAME_MS = 1000 / TARGET_FPS;
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (window.matchMedia("(pointer: coarse)").matches && window.innerWidth < 768) {
+    return true;
+  }
+  return false;
+}
+
+const rand = (min, max) => min + Math.random() * (max - min);
+const TWO_PI = Math.PI * 2;
+
+function normalizeAngle(a) {
+  const r = a % TWO_PI;
+  return r < 0 ? r + TWO_PI : r;
+}
+
+/* angular distance travelling forward from `from` to `to`, in 0..2π */
+function angleAhead(from, to) {
+  return normalizeAngle(to - from);
+}
+
+export default function RadarBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    const parent = canvas && canvas.parentElement;
+    if (!canvas || !parent) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let cx = 0;
+    let cy = 0;
+    let maxR = 0;
+    let dpr = 1;
+    let sweep = rand(0, TWO_PI);
+    let blips = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+    const SWEEP_SPEED = 0.5; // rad/sec
+
+    function seedBlips() {
+      const count = width < 640 ? 7 : width < 1100 ? 11 : 15;
+      blips = new Array(count).fill(0).map(() => ({
+        angle: rand(0, TWO_PI),
+        radius: rand(0.18, 0.95),
+        color: Math.random() < 0.3 ? CYAN : LIME,
+        life: 0, // 0 = dormant, >0 = fading in/out after the sweep passes
+      }));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const r = parent.getBoundingClientRect();
+      width = Math.max(1, Math.round(r.width));
+      height = Math.max(1, Math.round(r.height));
+      cx = width / 2;
+      cy = height / 2;
+      maxR = Math.min(width, height) * 0.46;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seedBlips();
+    }
+
+    function drawRings() {
+      ctx.strokeStyle = "rgba(187,223,77,0.14)";
+      ctx.lineWidth = 1;
+      for (let i = 1; i <= 4; i++) {
+        ctx.beginPath();
+        ctx.arc(cx, cy, (maxR * i) / 4, 0, TWO_PI);
+        ctx.stroke();
+      }
+      // crosshair
+      ctx.beginPath();
+      ctx.moveTo(cx - maxR, cy);
+      ctx.lineTo(cx + maxR, cy);
+      ctx.moveTo(cx, cy - maxR);
+      ctx.lineTo(cx, cy + maxR);
+      ctx.stroke();
+
+      // perimeter tick marks every 15deg
+      ctx.strokeStyle = "rgba(61,242,255,0.18)";
+      for (let d = 0; d < 360; d += 15) {
+        const a = (d * Math.PI) / 180;
+        const inner = maxR * 1.0;
+        const outer = maxR * 1.05;
+        ctx.beginPath();
+        ctx.moveTo(cx + Math.cos(a) * inner, cy + Math.sin(a) * inner);
+        ctx.lineTo(cx + Math.cos(a) * outer, cy + Math.sin(a) * outer);
+        ctx.stroke();
+      }
+    }
+
+    function drawSweep() {
+      const grad = ctx.createConicGradient
+        ? ctx.createConicGradient(sweep - 0.9, cx, cy)
+        : null;
+      // fallback path: draw a faded wedge using multiple thin arcs if
+      // createConicGradient isn't supported
+      const WEDGE = 0.9; // radians of trailing fade
+      if (grad) {
+        grad.addColorStop(0, "rgba(187,223,77,0)");
+        grad.addColorStop(0.94, "rgba(187,223,77,0)");
+        grad.addColorStop(1, "rgba(187,223,77,0.22)");
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.moveTo(cx, cy);
+        ctx.arc(cx, cy, maxR, 0, TWO_PI);
+        ctx.closePath();
+        ctx.fill();
+      } else {
+        const steps = 24;
+        for (let i = 0; i < steps; i++) {
+          const t = i / steps;
+          const a0 = sweep - WEDGE * (1 - t);
+          const a1 = sweep - WEDGE * (1 - (i + 1) / steps);
+          ctx.fillStyle = `rgba(187,223,77,${0.22 * t})`;
+          ctx.beginPath();
+          ctx.moveTo(cx, cy);
+          ctx.arc(cx, cy, maxR, a0, a1);
+          ctx.closePath();
+          ctx.fill();
+        }
+      }
+
+      // bright leading line
+      ctx.strokeStyle = "rgba(187,223,77,0.85)";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + Math.cos(sweep) * maxR, cy + Math.sin(sweep) * maxR);
+      ctx.stroke();
+    }
+
+    function drawBlips(dt) {
+      for (const b of blips) {
+        // wake the blip when the sweep line passes its angle
+        if (angleAhead(sweep - SWEEP_SPEED * dt, b.angle) < SWEEP_SPEED * dt + 0.02 &&
+            angleAhead(sweep, b.angle) > TWO_PI - 0.3) {
+          b.life = 1;
+        }
+        if (b.life <= 0) continue;
+        b.life -= dt * 0.55;
+        const x = cx + Math.cos(b.angle) * b.radius * maxR;
+        const y = cy + Math.sin(b.angle) * b.radius * maxR;
+        const alpha = Math.max(0, Math.min(1, b.life));
+        ctx.fillStyle = `rgba(${b.color[0]},${b.color[1]},${b.color[2]},${alpha})`;
+        ctx.beginPath();
+        ctx.arc(x, y, 3.2, 0, TWO_PI);
+        ctx.fill();
+        // faint ripple ring
+        ctx.strokeStyle = `rgba(${b.color[0]},${b.color[1]},${b.color[2]},${alpha * 0.4})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.arc(x, y, 3.2 + (1 - alpha) * 14, 0, TWO_PI);
+        ctx.stroke();
+      }
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      ctx.clearRect(0, 0, width, height);
+      sweep = normalizeAngle(sweep + SWEEP_SPEED * dt);
+
+      drawRings();
+      drawSweep();
+      drawBlips(dt);
+    }
+
+    resize();
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    const ro = "ResizeObserver" in window ? new ResizeObserver(() => resize()) : null;
+    if (ro) ro.observe(parent);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      if (ro) ro.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="radar-bg" aria-hidden="true" />;
+}

--- a/src/Components/cyber/Reveal.js
+++ b/src/Components/cyber/Reveal.js
@@ -1,0 +1,48 @@
+import React, { useRef } from "react";
+import { motion, useInView, useReducedMotion } from "framer-motion";
+
+/* ------------------------------------------------------------------ */
+/*  Reveal — the same scroll-in animation used on the homepage.        */
+/*  Fade + slide-up by default. `cut` upgrades it to a masked          */
+/*  "slide-up from behind a clipped edge", used for section headings.  */
+/*  Renders statically under prefers-reduced-motion.                   */
+/*                                                                      */
+/*  Requires the `.db-cut` CSS rule (defined in Database.css) when      */
+/*  used with `cut`.                                                    */
+/* ------------------------------------------------------------------ */
+export default function Reveal({ children, delay = 0, y = 40, className = "", cut = false }) {
+  const ref = useRef(null);
+  const reduce = useReducedMotion();
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+
+  if (reduce) {
+    return <div className={className}>{children}</div>;
+  }
+
+  if (cut) {
+    return (
+      <div ref={ref} className="db-cut">
+        <motion.div
+          className={className}
+          initial={{ y: "115%" }}
+          animate={inView ? { y: "0%" } : { y: "115%" }}
+          transition={{ duration: 0.85, delay, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {children}
+        </motion.div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-60px" }}
+      transition={{ duration: 0.7, delay, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/Components/cyber/ScrollHUD.css
+++ b/src/Components/cyber/ScrollHUD.css
@@ -1,0 +1,300 @@
+/* ==================================================================
+   ScrollHUD — scroll-progress HUD (NEURAL_BUILD // OS)
+   Desktop: fixed vertical rail, right edge, centred.
+   Mobile/tablet: slim horizontal progress bar under the navbar.
+   z-index 900 (navbar 1000, boot 100000). Only interactive nodes
+   receive pointer events.
+   ================================================================== */
+
+/* ------------------------------------------------------------------ */
+/*  DESKTOP RAIL  (>= 1101px)                                          */
+/* ------------------------------------------------------------------ */
+.shud-rail {
+  display: none; /* enabled at >=1101px */
+}
+
+.shud-bar {
+  /* --------- MOBILE / TABLET top progress bar (default) --------- */
+  position: fixed;
+  top: var(--nav-h);
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 900;
+  pointer-events: none;
+  background: var(--line-soft);
+  overflow: hidden;
+}
+
+.shud-bar-fill {
+  display: block;
+  height: 100%;
+  width: 100%;
+  transform-origin: left center;
+  transform: scaleX(var(--shud-progress, 0));
+  background: linear-gradient(90deg, var(--lime-deep), var(--lime));
+  box-shadow: var(--glow-lime-sm);
+  will-change: transform;
+}
+
+@media (min-width: 1101px) {
+  /* hide the mobile bar, show the rail */
+  .shud-bar {
+    display: none;
+  }
+
+  .shud-rail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+
+    position: fixed;
+    top: 50%;
+    right: clamp(6px, 0.7vw, 12px);
+    transform: translateY(-50%);
+    z-index: 900;
+
+    /* the rail itself is inert; only nodes opt back in */
+    pointer-events: none;
+    font-family: var(--font-mono);
+    user-select: none;
+  }
+
+  /* small mono readouts top & bottom of the rail */
+  .shud-rail-code {
+    font-size: 0.6rem;
+    letter-spacing: 0.18em;
+    color: var(--text-muted);
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    line-height: 1;
+  }
+  .shud-rail-top {
+    color: var(--cyan);
+    text-shadow: var(--text-glow-cyan);
+    transform: rotate(180deg);
+  }
+  .shud-rail-bot {
+    opacity: 0.7;
+  }
+
+  /* the track holds the progress line + the node list */
+  .shud-track {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--space-2) 0;
+
+    /* corner-bracket reticle framing */
+    border-top: 1px solid var(--line-strong);
+    border-bottom: 1px solid var(--line-strong);
+  }
+  .shud-track::before,
+  .shud-track::after {
+    content: "";
+    position: absolute;
+    right: -5px;
+    width: 5px;
+    height: 5px;
+    border-right: 1px solid var(--line-cyan);
+  }
+  .shud-track::before {
+    top: -1px;
+    border-top: 1px solid var(--line-cyan);
+  }
+  .shud-track::after {
+    bottom: -1px;
+    border-bottom: 1px solid var(--line-cyan);
+  }
+
+  /* base (dim) vertical guide line running the length of the nodes */
+  .shud-track-line {
+    position: absolute;
+    top: var(--space-4);
+    bottom: var(--space-4);
+    right: calc(var(--space-2) + 3px); /* aligns with node centres */
+    width: 1px;
+    background: var(--line);
+    pointer-events: none;
+  }
+  /* lime fill scaling with overall page scroll progress */
+  .shud-track-fill {
+    position: absolute;
+    top: var(--space-4);
+    right: calc(var(--space-2) + 2px);
+    width: 2px;
+    height: calc(100% - (2 * var(--space-4)));
+    transform-origin: top center;
+    transform: scaleY(var(--shud-progress, 0));
+    background: linear-gradient(
+      180deg,
+      var(--lime-bright),
+      var(--lime),
+      var(--lime-deep)
+    );
+    box-shadow: var(--glow-lime-sm);
+    pointer-events: none;
+    will-change: transform;
+  }
+
+  .shud-list {
+    list-style: none;
+    margin: 0;
+    padding: var(--space-3) 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    position: relative;
+    z-index: 1;
+  }
+
+  .shud-item {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  /* the whole clickable node = 44px min tap target */
+  .shud-node-btn {
+    -webkit-appearance: none;
+    appearance: none;
+    background: none;
+    border: 0;
+    margin: 0;
+    padding: 0 0 0 var(--space-3);
+    cursor: pointer;
+    pointer-events: auto; /* the ONE interactive surface on the rail */
+
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-3);
+
+    min-height: 44px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    transition: color var(--t-hover);
+  }
+
+  /* meta = code + label, sits to the LEFT of the node, slides/unfurls in */
+  .shud-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    overflow: hidden;
+    max-width: 0;
+    opacity: 0;
+    transform: translateX(8px);
+    transition: max-width var(--dur-4) var(--ease-out),
+      opacity var(--dur-3) var(--ease-out),
+      transform var(--dur-4) var(--ease-out);
+    white-space: nowrap;
+  }
+  .shud-code {
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+    color: var(--cyan);
+    text-shadow: var(--text-glow-cyan);
+  }
+  .shud-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    padding: 3px 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-xs);
+    background: var(--surface-nav-scrolled);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+
+  /* reveal the label ONLY on hover/focus so it never sits over section content */
+  .shud-node-btn:hover .shud-meta,
+  .shud-node-btn:focus-visible .shud-meta {
+    max-width: 220px;
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  /* the tick / node itself — kept small so the rail is a thin edge accent */
+  .shud-node {
+    position: relative;
+    flex: 0 0 auto;
+    width: 7px;
+    height: 7px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--line-strong);
+    border-radius: 50%;
+    background: var(--bg-1);
+    transition: border-color var(--t-hover), box-shadow var(--t-hover),
+      transform var(--t-hover);
+  }
+  .shud-node-dot {
+    width: 2px;
+    height: 2px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    transition: background var(--t-hover), transform var(--t-hover),
+      box-shadow var(--t-hover);
+  }
+
+  /* hover state */
+  .shud-node-btn:hover .shud-node,
+  .shud-node-btn:focus-visible .shud-node {
+    border-color: var(--cyan);
+    box-shadow: var(--glow-cyan-sm);
+  }
+  .shud-node-btn:hover .shud-node-dot,
+  .shud-node-btn:focus-visible .shud-node-dot {
+    background: var(--cyan);
+  }
+  .shud-node-btn:hover,
+  .shud-node-btn:focus-visible {
+    color: var(--text);
+  }
+
+  /* ACTIVE state — lights lime + glows */
+  .shud-item.is-active .shud-node-btn {
+    color: var(--lime);
+  }
+  .shud-item.is-active .shud-node {
+    border-color: var(--lime);
+    background: var(--bg-0);
+    box-shadow: var(--glow-lime-md);
+    transform: scale(1.15);
+  }
+  .shud-item.is-active .shud-node-dot {
+    background: var(--lime-bright);
+    box-shadow: var(--glow-lime-sm);
+    transform: scale(1.4);
+  }
+  .shud-item.is-active .shud-label {
+    color: var(--text-strong);
+    border-color: var(--line-strong);
+  }
+
+  /* focus ring lives on the node, not the whole button, for tidiness */
+  .shud-node-btn:focus-visible {
+    outline: none;
+  }
+  .shud-node-btn:focus-visible .shud-node {
+    box-shadow: var(--glow-cyan-sm), var(--focus-ring);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Reduced motion — kill the pulse; keep instant state changes        */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .shud-bar-fill,
+  .shud-track-fill,
+  .shud-meta,
+  .shud-node,
+  .shud-node-dot,
+  .shud-node-btn {
+    transition: none !important;
+  }
+}

--- a/src/Components/cyber/ScrollHUD.js
+++ b/src/Components/cyber/ScrollHUD.js
@@ -1,0 +1,274 @@
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useReducedMotion } from "framer-motion";
+import "./ScrollHUD.css";
+
+/* ==================================================================
+   ScrollHUD — NEURAL_BUILD // OS scroll-progress heads-up display
+   ------------------------------------------------------------------
+   Desktop (min-width:1025px): a fixed vertical rail pinned to the
+   right edge. Each section gets a node + mono code + label (label
+   unfurls on hover / when active). A lime progress line fills with
+   overall page scroll. Active section (IntersectionObserver) lights
+   lime. Clicking a node scrolls its target into view.
+
+   Mobile / tablet (max-width:1024px): the rail is hidden; instead a
+   slim horizontal progress bar sits fixed just under the navbar.
+
+   SECTIONS CONTRACT
+   -----------------
+   sections = [{ id, code, label }, ...]
+     id    string  — must match a document.getElementById(id) target.
+     code  string  — short mono index shown on the rail, e.g. "00".
+     label string  — human label revealed on hover / when active.
+
+   Targets whose id is not currently in the DOM (e.g. a conditionally
+   rendered section) are tolerated: their node renders inert and never
+   becomes active. Give matching id attributes in CyberHome, e.g.
+     <section id="sec-hero"> … </section>
+   ================================================================== */
+
+export default function ScrollHUD({ sections = [] }) {
+  const reduceMotion = useReducedMotion();
+
+  // overall page scroll progress, 0..1
+  const [progress, setProgress] = useState(0);
+  // id of the section currently considered "active"
+  const [activeId, setActiveId] = useState(sections[0]?.id ?? null);
+
+  const rafRef = useRef(0);
+  // per-id intersection ratio, so we can pick the most-visible section
+  const ratiosRef = useRef(new Map());
+  // the live IntersectionObserver + the set of ids already observed, so the
+  // re-scan interval can pick up late-mounting targets (e.g. the conditional
+  // RECENT feed) without rebuilding the observer.
+  const ioRef = useRef(null);
+  const observedIdsRef = useRef(new Set());
+
+  /* -------- overall scroll progress (rAF-throttled) --------
+     The site turns both <html> and <body> into scroll containers, so
+     window.scrollY can lag behind document.scrollingElement.scrollTop.
+     Read every plausible source and take the max to stay correct. */
+  const measure = useCallback(() => {
+    rafRef.current = 0;
+    const doc = document.documentElement;
+    const se = document.scrollingElement || doc;
+    const top = Math.max(
+      window.pageYOffset || 0,
+      window.scrollY || 0,
+      se.scrollTop || 0,
+      doc.scrollTop || 0,
+      document.body.scrollTop || 0
+    );
+    const max = Math.max(
+      se.scrollHeight - se.clientHeight,
+      doc.scrollHeight - doc.clientHeight,
+      0
+    );
+    const p = max > 0 ? Math.min(1, Math.max(0, top / max)) : 0;
+    setProgress(p);
+  }, []);
+
+  const requestMeasure = useCallback(() => {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(measure);
+  }, [measure]);
+
+  useEffect(() => {
+    // initial read + listeners
+    measure();
+    window.addEventListener("scroll", requestMeasure, { passive: true });
+    window.addEventListener("resize", requestMeasure, { passive: true });
+    // body can be the scroller under the overflow quirk
+    document.addEventListener("scroll", requestMeasure, {
+      passive: true,
+      capture: true,
+    });
+    return () => {
+      window.removeEventListener("scroll", requestMeasure);
+      window.removeEventListener("resize", requestMeasure);
+      document.removeEventListener("scroll", requestMeasure, { capture: true });
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = 0;
+    };
+  }, [measure, requestMeasure]);
+
+  /* -------- active section via IntersectionObserver --------
+     Watch every existing target; keep the intersection ratio for each
+     and promote the most-visible one to active. Rebuilds if the set of
+     present targets changes (e.g. a conditional section mounts). */
+  useEffect(() => {
+    if (!sections.length) return undefined;
+
+    const ratios = ratiosRef.current;
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = entry.target.id;
+          if (entry.isIntersecting) ratios.set(id, entry.intersectionRatio);
+          else ratios.delete(id);
+        }
+        // choose the most-visible currently-intersecting section, keeping
+        // document order as the tie-breaker
+        let bestId = null;
+        let bestRatio = -1;
+        for (const s of sections) {
+          const r = ratios.get(s.id);
+          if (r != null && r > bestRatio) {
+            bestRatio = r;
+            bestId = s.id;
+          }
+        }
+        if (bestId) setActiveId(bestId);
+      },
+      {
+        // a band centred on the viewport — a section is "active" while its
+        // body occupies the middle of the screen
+        rootMargin: "-45% 0px -45% 0px",
+        threshold: [0, 0.01, 0.25, 0.5, 0.75, 1],
+      }
+    );
+
+    ioRef.current = io;
+    const observedIds = observedIdsRef.current;
+    observedIds.clear();
+    for (const s of sections) {
+      const el = document.getElementById(s.id);
+      if (el) {
+        io.observe(el);
+        observedIds.add(s.id);
+      }
+    }
+
+    return () => {
+      io.disconnect();
+      ioRef.current = null;
+      observedIds.clear();
+      ratios.clear();
+    };
+    // Re-run when the section list identity changes. CyberHome passes a
+    // stable module-level array, so a conditional section that mounts later
+    // is picked up via the fallback scan below.
+  }, [sections]);
+
+  /* Late-mounting targets (e.g. the conditional RECENT feed) may not exist
+     on first observe. Re-scan a couple of times shortly after mount so they
+     get observed without needing the caller to change the sections array. */
+  useEffect(() => {
+    if (!sections.length) return undefined;
+    let tries = 0;
+    const id = window.setInterval(() => {
+      tries += 1;
+      // observe any target that has newly appeared in the DOM, guarding so
+      // each element is only observed once.
+      const io = ioRef.current;
+      const observedIds = observedIdsRef.current;
+      if (io) {
+        for (const s of sections) {
+          if (observedIds.has(s.id)) continue;
+          const el = document.getElementById(s.id);
+          if (el) {
+            io.observe(el);
+            observedIds.add(s.id);
+          }
+        }
+      }
+      const allPresent = sections.every((s) => observedIds.has(s.id));
+      if (allPresent || tries >= 6) {
+        window.clearInterval(id);
+        // nudge a re-measure once targets are settled
+        requestMeasure();
+      }
+    }, 400);
+    return () => window.clearInterval(id);
+  }, [sections, requestMeasure]);
+
+  const goTo = useCallback(
+    (id) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.scrollIntoView({
+        behavior: reduceMotion ? "auto" : "smooth",
+        block: "start",
+      });
+    },
+    [reduceMotion]
+  );
+
+  const onKeyDown = useCallback(
+    (e, id) => {
+      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+        e.preventDefault();
+        goTo(id);
+      }
+    },
+    [goTo]
+  );
+
+  if (!sections.length) return null;
+
+  const pct = Math.round(progress * 100);
+
+  return (
+    <>
+      {/* ---------- Desktop vertical rail (>=1025px) ---------- */}
+      <nav
+        className="shud-rail"
+        aria-label="Section navigation"
+        style={{ "--shud-progress": progress }}
+      >
+        <span className="shud-rail-code shud-rail-top" aria-hidden="true">
+          {String(pct).padStart(2, "0")}%
+        </span>
+
+        <div className="shud-track">
+          <span className="shud-track-line" aria-hidden="true" />
+          <span className="shud-track-fill" aria-hidden="true" />
+
+          <ul className="shud-list">
+            {sections.map((s) => {
+              const active = s.id === activeId;
+              return (
+                <li
+                  key={s.id}
+                  className={`shud-item${active ? " is-active" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="shud-node-btn"
+                    onClick={() => goTo(s.id)}
+                    onKeyDown={(e) => onKeyDown(e, s.id)}
+                    aria-current={active ? "true" : undefined}
+                    aria-label={`Go to ${s.label} section`}
+                    title={s.label}
+                  >
+                    <span className="shud-meta" aria-hidden="true">
+                      <span className="shud-code">{s.code}</span>
+                      <span className="shud-label">{s.label}</span>
+                    </span>
+                    <span className="shud-node" aria-hidden="true">
+                      <span className="shud-node-dot" />
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <span className="shud-rail-code shud-rail-bot" aria-hidden="true">
+          SCROLL
+        </span>
+      </nav>
+
+      {/* ---------- Mobile / tablet top bar (<=1024px) ---------- */}
+      <div
+        className="shud-bar"
+        role="presentation"
+        aria-hidden="true"
+        style={{ "--shud-progress": progress }}
+      >
+        <span className="shud-bar-fill" />
+      </div>
+    </>
+  );
+}

--- a/src/Components/cyber/TransmissionBG.css
+++ b/src/Components/cyber/TransmissionBG.css
@@ -1,0 +1,19 @@
+.transmission-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  contain: strict;
+  opacity: 0.8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transmission-bg {
+    display: none;
+  }
+}

--- a/src/Components/cyber/TransmissionBG.js
+++ b/src/Components/cyber/TransmissionBG.js
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef } from "react";
+import "./TransmissionBG.css";
+
+/* ==================================================================
+   TransmissionBG — vertical glyph-stream "data download" effect, for
+   the Articles hero. Classic matrix-rain technique (a translucent
+   fill fades the previous frame instead of tracking trail arrays),
+   themed lime/cyan. Reads as "decoding archived knowledge" rather
+   than a flat photo. Sized to its parent, same conventions as the
+   other cyber canvases.
+   ================================================================== */
+
+const CHARSET = "01#/$%&ABCDEF{}<>=+*".split("");
+
+const TARGET_FPS = 30;
+const FRAME_MS = 1000 / TARGET_FPS;
+const CHAR_SIZE = 16;
+
+function shouldSkip() {
+  if (typeof window === "undefined" || !window.matchMedia) return true;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (window.matchMedia("(pointer: coarse)").matches && window.innerWidth < 768) {
+    return true;
+  }
+  return false;
+}
+
+const rand = (min, max) => min + Math.random() * (max - min);
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+export default function TransmissionBG() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (shouldSkip()) return undefined;
+
+    const canvas = canvasRef.current;
+    const parent = canvas && canvas.parentElement;
+    if (!canvas || !parent) return undefined;
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return undefined;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let columns = [];
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = true;
+
+    function seedColumns() {
+      const count = Math.floor(width / 22);
+      columns = new Array(count).fill(0).map((_, i) => ({
+        x: i * 22 + 6,
+        y: rand(-40, 0),
+        speed: rand(3.5, 8.5), // rows/sec
+        color: Math.random() < 0.28 ? "61,242,255" : "187,223,77",
+        active: Math.random() < 0.75,
+        nextToggle: rand(2, 8),
+      }));
+    }
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const r = parent.getBoundingClientRect();
+      width = Math.max(1, Math.round(r.width));
+      height = Math.max(1, Math.round(r.height));
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = width + "px";
+      canvas.style.height = height + "px";
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.font = `${CHAR_SIZE - 2}px var(--font-mono, monospace)`;
+      ctx.textAlign = "center";
+      seedColumns();
+    }
+
+    function step(now) {
+      if (!running) return;
+      rafId = window.requestAnimationFrame(step);
+
+      const elapsed = now - lastFrame;
+      if (elapsed < FRAME_MS) return;
+      const dt = Math.min(elapsed, 100) / 1000;
+      lastFrame = now - (elapsed % FRAME_MS);
+
+      // fade the previous frame instead of clearing — this is what
+      // produces the trailing-glyph look with almost no bookkeeping
+      ctx.fillStyle = "rgba(5,7,10,0.14)";
+      ctx.fillRect(0, 0, width, height);
+
+      const maxRow = height / CHAR_SIZE + 4;
+
+      for (const col of columns) {
+        col.nextToggle -= dt;
+        if (col.nextToggle <= 0) {
+          col.active = !col.active;
+          col.nextToggle = col.active ? rand(3, 9) : rand(1.5, 4);
+        }
+        if (!col.active) continue;
+
+        col.y += col.speed * dt;
+        if (col.y > maxRow) {
+          col.y = rand(-10, 0);
+          col.speed = rand(3.5, 8.5);
+        }
+
+        const py = col.y * CHAR_SIZE;
+        ctx.fillStyle = `rgba(${col.color},0.9)`;
+        ctx.fillText(pick(CHARSET), col.x, py);
+      }
+    }
+
+    resize();
+    // start from a mostly-opaque canvas so the very first frames don't
+    // pop in from nothing
+    ctx.fillStyle = "rgba(5,7,10,1)";
+    ctx.fillRect(0, 0, width, height);
+    lastFrame = performance.now();
+    rafId = window.requestAnimationFrame(step);
+
+    const ro = "ResizeObserver" in window ? new ResizeObserver(() => resize()) : null;
+    if (ro) ro.observe(parent);
+
+    let resizeTimer = 0;
+    function onResize() {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(resize, 150);
+    }
+    window.addEventListener("resize", onResize);
+
+    function onVisibility() {
+      if (document.hidden) {
+        running = false;
+        window.cancelAnimationFrame(rafId);
+      } else if (!running) {
+        running = true;
+        lastFrame = performance.now();
+        rafId = window.requestAnimationFrame(step);
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      running = false;
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(resizeTimer);
+      if (ro) ro.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="transmission-bg" aria-hidden="true" />;
+}


### PR DESCRIPTION
## What this does
Adds the shared component library the whole redesign draws from — 17 new files under `src/Components/cyber/`, no page wiring yet.

- **Hero background canvases** (one per page identity): CircuitBG (drifting node constellation), CircuitTraceBG (animated PCB traces), HoloGridBG, PartsBG (floating schematic parts), RadarBG (sweep + rings), TransmissionBG (signal static).
- **Cursor.js** — neon dot + lagging-ring custom cursor, with a `Magnetic` wrapper for buttons. Inert on touch devices.
- **Reveal.js** — the scroll-in animation primitive (fade+slide, plus a masked "cut" variant for section headings).
- **ScrollHUD.js** — the scroll rail: on desktop a fixed right-edge rail with one node per section (mono code + label, lime progress line, IntersectionObserver-driven active state, click-to-jump, keyboard accessible); on ≤1024px it degrades to a slim progress bar under the navbar. Tolerates section ids that mount late or never (conditional sections).

## Review notes
- All canvases are fixed, pointer-inert, layout-inert (`contain: strict`) and render nothing under `prefers-reduced-motion`.
- Components only — nothing imports them until the page PRs land, so this is safe to merge early.

---
**Series notes** (part of a 14-PR redesign, preview: https://eclub-beta.netlify.app): every PR touches a disjoint set of files, so they merge conflict-free in any order (recommended: 01 → 14). The site builds only once the whole series is in. Nothing deploys to the live site until `npm run deploy` is run after the series lands.