### PR TITLE
Homepage: 3D reactor hero, boot sequence and snap-scroll cyber chapters

### DIFF
--- a/src/Components/cyber/BootSequence.css
+++ b/src/Components/cyber/BootSequence.css
@@ -1,0 +1,237 @@
+/* ==================================================================
+   BootSequence — first-load boot overlay (NEURAL_BUILD // OS)
+   Sits ABOVE the navbar. Compositor-only animation (transform/opacity),
+   tokens from :root only. No horizontal overflow.
+   ================================================================== */
+
+.boot {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  background: var(--bg-0);
+  color: var(--text);
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  /* curtain starts fully covering the viewport */
+  clip-path: inset(0 0 0 0);
+  will-change: clip-path, opacity;
+}
+
+/* curtain-up wipe: reveal from the bottom, cutting to nothing at the top */
+.boot--wipe {
+  clip-path: inset(0 0 100% 0);
+  transition: clip-path var(--dur-5, 500ms) var(--ease-out);
+}
+
+/* reduced-motion path: plain fade, no movement */
+.boot--fade {
+  opacity: 0;
+  transition: opacity 400ms linear;
+}
+
+/* ---- animated perspective grid backdrop ---- */
+.boot__grid {
+  position: absolute;
+  inset: -2px;
+  background-image:
+    linear-gradient(var(--line-soft) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line-soft) 1px, transparent 1px);
+  background-size: 46px 46px;
+  animation: boot-grid 5s linear infinite;
+  opacity: 0.7;
+  pointer-events: none;
+}
+@keyframes boot-grid {
+  to { background-position: 46px 46px; }
+}
+
+/* ---- scanline sheen ---- */
+.boot__scan {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0px,
+    rgba(0, 0, 0, 0) 2px,
+    rgba(0, 0, 0, 0.22) 3px,
+    rgba(0, 0, 0, 0) 4px
+  );
+  mix-blend-mode: overlay;
+  pointer-events: none;
+}
+
+/* ---- corner-bracket reticle ---- */
+.boot__bracket {
+  position: absolute;
+  width: 26px;
+  height: 26px;
+  border: 2px solid var(--line-cyan);
+  pointer-events: none;
+  opacity: 0.85;
+}
+.boot__bracket--tl {
+  top: 18px; left: 18px;
+  border-right: none; border-bottom: none;
+}
+.boot__bracket--tr {
+  top: 18px; right: 18px;
+  border-left: none; border-bottom: none;
+}
+.boot__bracket--bl {
+  bottom: 18px; left: 18px;
+  border-right: none; border-top: none;
+}
+.boot__bracket--br {
+  bottom: 18px; right: 18px;
+  border-left: none; border-top: none;
+}
+
+/* ---- terminal stage ---- */
+.boot__stage {
+  position: relative;
+  z-index: 2;
+  width: min(92vw, 560px);
+  background: var(--bg-term);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-terminal), var(--glow-cyan-md);
+  overflow: hidden;
+  animation: boot-stage-in var(--dur-5, 450ms) var(--ease-out) both;
+}
+@keyframes boot-stage-in {
+  from { opacity: 0; transform: translateY(10px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* terminal title bar */
+.boot__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: var(--bg-term-bar);
+  border-bottom: 1px solid var(--line);
+}
+.boot__dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.boot__dot--r { background: var(--dot-red); }
+.boot__dot--y { background: var(--dot-yellow); }
+.boot__dot--g { background: var(--dot-green); }
+.boot__headlabel {
+  margin-left: 10px;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+/* typed lines */
+.boot__term {
+  padding: 22px 22px 8px;
+  min-height: 168px;
+  font-size: clamp(0.82rem, 2.6vw, 0.95rem);
+  line-height: 1.9;
+}
+.boot__line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.boot__line--dim .boot__text { color: var(--text-dim); }
+.boot__line--hero {
+  margin-top: 10px;
+}
+.boot__line--hero .boot__text {
+  color: var(--lime-bright);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-shadow: var(--text-glow-lime);
+}
+
+/* blinking cyan caret */
+.boot__caret {
+  display: inline-block;
+  width: 9px;
+  height: 1.05em;
+  transform: translateY(2px);
+  background: var(--cyan);
+  box-shadow: var(--glow-cyan-sm);
+  animation: boot-blink 1s steps(1) infinite;
+}
+@keyframes boot-blink {
+  50% { opacity: 0; }
+}
+
+/* progress bar */
+.boot__progress {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 22px 20px;
+}
+.boot__track {
+  position: relative;
+  flex: 1;
+  height: 3px;
+  background: var(--line-soft);
+  border-radius: var(--r-pill);
+  overflow: hidden;
+}
+.boot__fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(0);
+  background: linear-gradient(90deg, var(--cyan), var(--lime));
+  box-shadow: var(--glow-lime-sm);
+  transition: transform 120ms linear;
+  will-change: transform;
+}
+.boot__pct {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  color: var(--cyan);
+  min-width: 3.4em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* skip hint */
+.boot__hint {
+  position: absolute;
+  bottom: 30px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  z-index: 2;
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  animation: boot-hint 2.2s ease-in-out infinite;
+}
+@keyframes boot-hint {
+  0%, 100% { opacity: 0.35; }
+  50%      { opacity: 0.8; }
+}
+
+/* ---- reduced motion: kill decorative animation ---- */
+@media (prefers-reduced-motion: reduce) {
+  .boot__grid,
+  .boot__caret,
+  .boot__hint,
+  .boot__stage,
+  .boot__fill {
+    animation: none;
+    transition: none;
+  }
+  .boot__caret { opacity: 1; }
+}

--- a/src/Components/cyber/BootSequence.js
+++ b/src/Components/cyber/BootSequence.js
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import "./BootSequence.css";
+
+/* ------------------------------------------------------------------ */
+/*  BootSequence — first-load "boot into the club OS" overlay.        */
+/*                                                                     */
+/*  Full-screen fixed overlay above the navbar. Types ~5 mono boot    */
+/*  lines with a blinking cyan caret, drives a 0->100% progress bar,  */
+/*  then curtains up with a clip-path wipe and calls onFinish() once. */
+/*                                                                     */
+/*  Any keydown / click / touchstart skips straight to the wipe.      */
+/*  prefers-reduced-motion: no typing, final frame, quick fade.       */
+/* ------------------------------------------------------------------ */
+
+const LINES = [
+  { text: "> initializing electronics core...", tone: "dim" },
+  { text: "> loading circuit database...", tone: "dim" },
+  { text: "> compiling project modules...", tone: "dim" },
+  { text: "> calibrating reactor...", tone: "dim" },
+  { text: "NEURAL_BUILD // ONLINE", tone: "hero" },
+];
+
+/* Timing budget (auto-run ≈ 1.6s of typing, then a ~0.45s wipe). */
+const TYPE_MS = 9; // per-character type speed
+const LINE_GAP_MS = 70; // pause between lines
+const HOLD_MS = 220; // linger on the final frame before wiping
+const WIPE_MS = 450; // curtain-up clip-path duration
+const FADE_MS = 380; // reduced-motion fade-out duration
+
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export default function BootSequence({ onFinish }) {
+  const reduced = useRef(prefersReducedMotion());
+
+  // Typed text, one string per line (built up character by character).
+  const [typed, setTyped] = useState(() => LINES.map(() => ""));
+  const [activeLine, setActiveLine] = useState(0);
+  const [progress, setProgress] = useState(0);
+  const [phase, setPhase] = useState("boot"); // "boot" -> "wipe" | "fade"
+
+  // Guards so onFinish fires exactly once and timers don't double-run.
+  const finishedRef = useRef(false);
+  const exitingRef = useRef(false);
+  const timersRef = useRef([]);
+  const rafRef = useRef(0);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = 0;
+  }, []);
+
+  const finish = useCallback(() => {
+    if (finishedRef.current) return;
+    finishedRef.current = true;
+    onFinish && onFinish();
+  }, [onFinish]);
+
+  // Kick off the exit (wipe or fade), then finish once it completes.
+  const exit = useCallback(() => {
+    if (exitingRef.current) return;
+    exitingRef.current = true;
+    clearTimers();
+
+    // Snap the visual to its finished state so a skip never shows a
+    // half-typed frame behind the curtain.
+    setTyped(LINES.map((l) => l.text));
+    setActiveLine(LINES.length - 1);
+    setProgress(100);
+
+    const mode = reduced.current ? "fade" : "wipe";
+    setPhase(mode);
+    const dur = reduced.current ? FADE_MS : WIPE_MS;
+    const id = setTimeout(finish, dur);
+    timersRef.current.push(id);
+  }, [clearTimers, finish]);
+
+  /* -------- global skip: any key / click / touch -> exit -------- */
+  useEffect(() => {
+    const skip = () => exit();
+    window.addEventListener("keydown", skip);
+    window.addEventListener("pointerdown", skip);
+    window.addEventListener("touchstart", skip, { passive: true });
+    return () => {
+      window.removeEventListener("keydown", skip);
+      window.removeEventListener("pointerdown", skip);
+      window.removeEventListener("touchstart", skip);
+    };
+  }, [exit]);
+
+  /* -------- reduced motion: show final frame, fade, done -------- */
+  useEffect(() => {
+    if (!reduced.current) return;
+    setTyped(LINES.map((l) => l.text));
+    setActiveLine(LINES.length - 1);
+    setProgress(100);
+    // Give the final frame a beat to paint, then fade out.
+    const id = setTimeout(exit, 180);
+    timersRef.current.push(id);
+    return clearTimers;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /* -------- typing driver (skipped when reduced motion) -------- */
+  useEffect(() => {
+    if (reduced.current) return;
+
+    // Total characters across all lines, for progress mapping.
+    const totalChars = LINES.reduce((n, l) => n + l.text.length, 0);
+    let li = 0; // line index
+    let ci = 0; // char index within current line
+    let done = 0; // chars committed so far
+
+    const typeNext = () => {
+      if (exitingRef.current) return;
+      const line = LINES[li];
+      ci += 1;
+      done += 1;
+      const slice = line.text.slice(0, ci);
+
+      setActiveLine(li);
+      setTyped((prev) => {
+        const next = prev.slice();
+        next[li] = slice;
+        return next;
+      });
+      // Reserve the last slice of the bar for the hold/wipe so it visibly
+      // reaches 100% right as the curtain rises.
+      setProgress(Math.min(98, Math.round((done / totalChars) * 98)));
+
+      if (ci < line.text.length) {
+        push(typeNext, TYPE_MS);
+      } else if (li < LINES.length - 1) {
+        li += 1;
+        ci = 0;
+        push(typeNext, LINE_GAP_MS);
+      } else {
+        // All lines typed — fill to 100%, hold, then wipe.
+        setProgress(100);
+        push(exit, HOLD_MS);
+      }
+    };
+
+    const push = (fn, ms) => {
+      const id = setTimeout(fn, ms);
+      timersRef.current.push(id);
+    };
+
+    push(typeNext, 200); // brief beat before the first character
+    return clearTimers;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      className={`boot ${phase === "wipe" ? "boot--wipe" : ""} ${
+        phase === "fade" ? "boot--fade" : ""
+      }`}
+      role="status"
+      aria-live="polite"
+      aria-label="System booting"
+    >
+      <div className="boot__grid" aria-hidden="true" />
+      <div className="boot__scan" aria-hidden="true" />
+
+      {/* corner-bracket reticle */}
+      <span className="boot__bracket boot__bracket--tl" aria-hidden="true" />
+      <span className="boot__bracket boot__bracket--tr" aria-hidden="true" />
+      <span className="boot__bracket boot__bracket--bl" aria-hidden="true" />
+      <span className="boot__bracket boot__bracket--br" aria-hidden="true" />
+
+      <div className="boot__stage">
+        <div className="boot__head" aria-hidden="true">
+          <span className="boot__dot boot__dot--r" />
+          <span className="boot__dot boot__dot--y" />
+          <span className="boot__dot boot__dot--g" />
+          <span className="boot__headlabel">neural_build // os · boot</span>
+        </div>
+
+        <div className="boot__term" aria-hidden="true">
+          {LINES.map((line, i) => {
+            const isActive = i === activeLine;
+            const content = typed[i];
+            if (!content) return null;
+            return (
+              <div
+                key={i}
+                className={`boot__line boot__line--${line.tone}`}
+              >
+                <span className="boot__text">{content}</span>
+                {isActive && <span className="boot__caret" aria-hidden="true" />}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="boot__progress" aria-hidden="true">
+          <div className="boot__track">
+            <div
+              className="boot__fill"
+              style={{ transform: `scaleX(${progress / 100})` }}
+            />
+          </div>
+          <div className="boot__pct">
+            {String(Math.round(progress)).padStart(3, "0")}%
+          </div>
+        </div>
+      </div>
+
+      <div className="boot__hint" aria-hidden="true">
+        PRESS ANY KEY · TAP TO SKIP
+      </div>
+    </div>
+  );
+}

--- a/src/Components/cyber/CyberHome.css
+++ b/src/Components/cyber/CyberHome.css
@@ -1,0 +1,1113 @@
+/* ==================================================================
+   CYBER HOME — Electronics Club, IIT Kanpur
+   Futuristic / neon / HUD redesign
+   ================================================================== */
+
+/* ---- Scroll-snap: each chapter "cuts in" and lands like a premium product page.
+   Scoped to `.home-snap` (added to <html> by CyberHome) so it never leaks to
+   other routes. ---- */
+html { background: var(--bg-0); }
+/* full-page snap: one section at a time, no resting in between, no scrollbar */
+html.home-snap {
+  scroll-snap-type: y mandatory;
+  scroll-padding-top: var(--nav-h);
+  scrollbar-width: none;          /* Firefox */
+  -ms-overflow-style: none;       /* old Edge */
+}
+html.home-snap::-webkit-scrollbar { width: 0; height: 0; display: none; }
+html.home-snap body { scrollbar-width: none; }
+html.home-snap body::-webkit-scrollbar { width: 0; height: 0; display: none; }
+/* the footer (outside .ch-root) is the final snap target. align:END puts its
+   snap point at the document end so it's actually reachable (a `start` snap
+   point would sit past max-scroll and mandatory snap could never rest on it). */
+html.home-snap .footer-cyber {
+  scroll-snap-align: end;
+  scroll-snap-stop: normal;
+}
+
+.ch-root {
+  --lime: #bbdf4d;
+  --cyan: #3df2ff;
+  --ink: #05070a;
+  --ink-2: #0a0e14;
+  --line: rgba(187, 223, 77, 0.14);
+  --txt: #d7e0d0;
+  --muted: #8b968a;
+
+  background: var(--ink);
+  color: var(--txt);
+  font-family: "Space Grotesk", sans-serif;
+  overflow-x: clip;
+  position: relative;
+  text-align: left;
+}
+
+.ch-root *,
+.ch-root *::before,
+.ch-root *::after {
+  box-sizing: border-box;
+}
+
+/* mono helper */
+.ch-root .ch-eyebrow,
+.ch-root .ch-hud,
+.ch-root .ch-kicker,
+.ch-root .ch-domain-tag,
+.ch-root .ch-terminal pre,
+.ch-root .ch-btn,
+.ch-root .ch-scroll-cue span {
+  font-family: "Share Tech Mono", monospace;
+}
+
+/* ============================ HERO ============================ */
+.ch-hero {
+  position: relative;
+  z-index: 1;
+  height: 100vh;
+  height: 100svh;
+  min-height: 520px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  background:
+    radial-gradient(120% 80% at 50% 0%, rgba(187, 223, 77, 0.08), transparent 60%),
+    radial-gradient(80% 60% at 50% 100%, rgba(61, 242, 255, 0.06), transparent 60%),
+    var(--ink);
+}
+
+.ch-canvas,
+.ch-canvas > div,
+.ch-canvas canvas {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+}
+.ch-canvas-fallback {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(40% 40% at 50% 45%, rgba(187, 223, 77, 0.18), transparent 70%);
+  animation: ch-pulse 2s ease-in-out infinite;
+}
+@keyframes ch-pulse {
+  50% { opacity: 0.5; }
+}
+
+/* moving perspective grid */
+.ch-grid-overlay {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask-image: radial-gradient(circle at 50% 50%, black 10%, transparent 78%);
+  -webkit-mask-image: radial-gradient(circle at 50% 50%, black 10%, transparent 78%);
+  animation: ch-grid-move 12s linear infinite;
+  pointer-events: none;
+}
+@keyframes ch-grid-move {
+  to { background-position: 46px 46px; }
+}
+
+.ch-scanlines {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0px,
+    rgba(0, 0, 0, 0) 2px,
+    rgba(0, 0, 0, 0.22) 3px,
+    rgba(0, 0, 0, 0) 4px
+  );
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  opacity: 0.6;
+}
+.ch-vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 220px 60px rgba(0, 0, 0, 0.9);
+}
+
+/* HUD corner labels */
+.ch-hud {
+  position: absolute;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: rgba(187, 223, 77, 0.65);
+  z-index: 3;
+  pointer-events: none;
+}
+.ch-hud::before {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1px solid rgba(187, 223, 77, 0.5);
+}
+.ch-hud-tl { top: 90px; left: 26px; padding-left: 22px; }
+.ch-hud-tl::before { top: 0; left: 0; border-right: 0; border-bottom: 0; }
+.ch-hud-tr { top: 90px; right: 26px; padding-right: 22px; text-align: right; }
+.ch-hud-tr::before { top: 0; right: 0; border-left: 0; border-bottom: 0; }
+/* lifted clear of the ticker that's docked at the hero's bottom edge */
+.ch-hud-bl { bottom: 64px; left: 26px; padding-left: 22px; }
+.ch-hud-bl::before { bottom: 0; left: 0; border-right: 0; border-top: 0; }
+.ch-hud-br { bottom: 64px; right: 26px; padding-right: 22px; text-align: right; }
+.ch-hud-br::before { bottom: 0; right: 0; border-left: 0; border-top: 0; }
+
+/* hero text */
+.ch-hero-content {
+  position: relative;
+  z-index: 4;
+  text-align: center;
+  padding: 0 20px;
+  max-width: 1100px;
+}
+.ch-eyebrow {
+  color: var(--cyan);
+  font-size: 0.82rem;
+  margin: 0 0 18px;
+  text-shadow: 0 0 12px rgba(61, 242, 255, 0.6);
+}
+.ch-title {
+  font-size: clamp(2.6rem, 9vw, 7rem);
+  font-weight: 700;
+  line-height: 0.95;
+  margin: 0;
+  letter-spacing: 0.02em;
+  color: #fff;
+  position: relative;
+  text-shadow: 0 0 40px rgba(187, 223, 77, 0.35);
+}
+.ch-title::before,
+.ch-title::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  clip-path: inset(0 0 0 0);
+}
+.ch-title::before {
+  color: var(--cyan);
+  animation: ch-glitch-a 3.5s infinite steps(2);
+  mix-blend-mode: screen;
+}
+.ch-title::after {
+  color: var(--lime);
+  animation: ch-glitch-b 3.5s infinite steps(2);
+  mix-blend-mode: screen;
+}
+@keyframes ch-glitch-a {
+  0%, 92%, 100% { transform: translate(0); opacity: 0; }
+  93% { transform: translate(-3px, 1px); opacity: 0.7; }
+  95% { transform: translate(2px, -1px); opacity: 0.7; }
+  97% { transform: translate(-2px, 0); opacity: 0; }
+}
+@keyframes ch-glitch-b {
+  0%, 90%, 100% { transform: translate(0); opacity: 0; }
+  91% { transform: translate(3px, -1px); opacity: 0.6; }
+  94% { transform: translate(-2px, 1px); opacity: 0.6; }
+  96% { transform: translate(1px, 0); opacity: 0; }
+}
+
+.ch-tagline {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 22px 0 34px;
+  font-size: clamp(0.75rem, 2vw, 1rem);
+  letter-spacing: 0.35em;
+  color: var(--txt);
+  font-weight: 500;
+}
+.ch-dot { color: var(--lime); }
+
+/* buttons */
+.ch-cta-row {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.ch-btn {
+  --b: var(--lime);
+  position: relative;
+  display: inline-block;
+  padding: 14px 30px;
+  font-size: 0.82rem;
+  letter-spacing: 0.2em;
+  text-decoration: none;
+  color: var(--ink);
+  background: var(--b);
+  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+  border: none;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-family: "Share Tech Mono", monospace;
+  font-weight: 700;
+}
+.ch-btn span { position: relative; z-index: 2; }
+.ch-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  transform: translateX(-101%) skewX(-20deg);
+  transition: transform 0.45s ease;
+}
+.ch-btn:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0 26px rgba(187, 223, 77, 0.5);
+}
+.ch-btn:hover::after { transform: translateX(101%) skewX(-20deg); }
+.ch-btn-ghost {
+  background: transparent;
+  color: var(--lime);
+  border: 1px solid rgba(187, 223, 77, 0.5);
+  box-shadow: inset 0 0 0 0 rgba(187, 223, 77, 0.1);
+}
+.ch-btn-ghost::after { background: rgba(187, 223, 77, 0.14); }
+.ch-btn-ghost:hover { box-shadow: 0 0 22px rgba(187, 223, 77, 0.3); }
+.ch-inline { margin-top: 18px; }
+/* clip-path + overflow:hidden eat the global box-shadow focus ring, so use an
+   OUTLINE (painted outside the box) for keyboard focus on buttons */
+.ch-btn:focus-visible {
+  outline: 2px solid var(--lime);
+  outline-offset: 3px;
+  box-shadow: none;
+}
+.ch-cap-link:focus-visible,
+.ch-readmore:focus-visible {
+  outline: 2px solid var(--lime);
+  outline-offset: 3px;
+}
+
+/* scroll cue */
+.ch-scroll-cue {
+  position: absolute;
+  bottom: 84px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.65rem;
+  letter-spacing: 0.3em;
+}
+.ch-scroll-track {
+  width: 22px;
+  height: 38px;
+  border: 1px solid rgba(187, 223, 77, 0.4);
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+  padding-top: 6px;
+}
+.ch-scroll-dot {
+  width: 4px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--lime);
+  animation: ch-scroll 1.6s ease-in-out infinite;
+}
+@keyframes ch-scroll {
+  0%, 100% { transform: translateY(0); opacity: 1; }
+  70% { transform: translateY(14px); opacity: 0.2; }
+}
+
+/* ============================ SHARED SECTION ============================ */
+.ch-root section {
+  position: relative;
+  padding: 100px 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+/* the hero is full-bleed so the 3D reactor fills the whole screen */
+.ch-root section.ch-hero {
+  max-width: none;
+  padding: 0;
+}
+
+/* Full-viewport "chapter" — each is exactly one screen; content is designed to
+   fit so mandatory snap can move section-to-section with nothing in between. */
+.ch-chapter {
+  /* content chapters fill exactly the area below the sticky nav so their
+     centered content sits in the true visual centre of the screen */
+  height: calc(100vh - var(--nav-h));
+  height: calc(100svh - var(--nav-h));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  z-index: 1;
+}
+/* fixed-height chapters use tighter, viewport-relative vertical padding */
+.ch-root section.ch-chapter {
+  padding-top: clamp(28px, 5vh, 56px);
+  padding-bottom: clamp(28px, 5vh, 56px);
+}
+/* the scroll-driven wrapper — holds each chapter's content while it rises/recedes */
+.ch-chapter-inner {
+  width: 100%;
+  will-change: transform, opacity;
+}
+.ch-section-head { margin-bottom: 54px; }
+/* masked "cut in" reveal — clips the rising content, small padding keeps glow intact */
+.ch-cut { overflow: clip; padding: 8px 6px; margin: -8px -6px; }
+.ch-cut.ch-section-head { margin-bottom: 46px; }
+.ch-kicker {
+  display: inline-block;
+  color: var(--cyan);
+  font-size: 0.78rem;
+  letter-spacing: 0.3em;
+  margin-bottom: 14px;
+  padding-left: 26px;
+  position: relative;
+}
+.ch-kicker::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 18px;
+  height: 1px;
+  background: var(--cyan);
+}
+.ch-h2 {
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 700;
+  color: #fff;
+  margin: 0;
+  line-height: 1.05;
+}
+.ch-hl {
+  color: var(--lime);
+  text-shadow: 0 0 24px rgba(187, 223, 77, 0.45);
+}
+
+/* ============================ ABOUT ============================ */
+.ch-about-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 40px;
+  align-items: start;
+}
+.ch-about-panel {
+  border: 1px solid var(--line);
+  border-left: 2px solid var(--lime);
+  padding: 34px;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+  font-size: 1.02rem;
+  line-height: 1.75;
+  /* keep the chapter to one screen — expanded "read more" scrolls inside here */
+  max-height: 62svh;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.ch-about-panel::-webkit-scrollbar { display: none; }
+.ch-about-panel p { margin: 0 0 18px; color: var(--txt); }
+.ch-lime { color: var(--lime) !important; }
+.ch-sub {
+  color: var(--cyan);
+  letter-spacing: 0.12em;
+  margin: 24px 0 10px;
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+.ch-readmore {
+  background: none;
+  border: 1px solid rgba(187, 223, 77, 0.4);
+  color: var(--lime);
+  padding: 10px 22px;
+  font-family: "Share Tech Mono", monospace;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+  margin-top: 10px;
+  transition: all 0.2s;
+}
+.ch-readmore:hover {
+  background: rgba(187, 223, 77, 0.12);
+  box-shadow: 0 0 18px rgba(187, 223, 77, 0.3);
+}
+
+/* terminal card */
+.ch-terminal {
+  border: 1px solid var(--line);
+  background: #060a0f;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+.ch-term-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: #0c1219;
+  border-bottom: 1px solid var(--line);
+}
+.ch-term-bar i {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #2a3340;
+}
+.ch-term-bar i:first-child { background: #ff5f56; }
+.ch-term-bar i:nth-child(2) { background: #ffbd2e; }
+.ch-term-bar i:nth-child(3) { background: var(--lime); }
+.ch-term-bar span {
+  margin-left: 8px;
+  color: var(--muted);
+  font-family: "Share Tech Mono", monospace;
+  font-size: 0.78rem;
+}
+.ch-terminal pre {
+  margin: 0;
+  padding: 22px;
+  color: var(--lime);
+  font-size: 0.86rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+/* ============================ DOMAINS (deck) ============================ */
+.ch-domain-card {
+  position: relative;
+  flex: 0 0 min(300px, 80vw);
+  scroll-snap-align: start;
+  border: 1px solid var(--line);
+  background: var(--ink-2);
+  overflow: hidden;
+  transition: transform 0.15s ease, box-shadow 0.3s ease, border-color 0.3s;
+  transform-style: preserve-3d;
+  will-change: transform;
+}
+.ch-domain-card:hover {
+  border-color: rgba(187, 223, 77, 0.55);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+}
+.ch-domain-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    240px circle at var(--mx, 50%) var(--my, 0%),
+    rgba(187, 223, 77, 0.18),
+    transparent 60%
+  );
+  opacity: 0;
+  transition: opacity 0.3s;
+  z-index: 3;
+  pointer-events: none;
+}
+.ch-domain-card:hover .ch-domain-glow { opacity: 1; }
+.ch-domain-img {
+  height: clamp(130px, 20vh, 170px);
+  background-size: cover;
+  background-position: center;
+  filter: grayscale(0.4) contrast(1.05) brightness(0.75);
+  transition: filter 0.4s, transform 0.6s;
+}
+.ch-domain-card:hover .ch-domain-img {
+  filter: grayscale(0) contrast(1.1) brightness(0.95);
+  transform: scale(1.06);
+}
+.ch-domain-body { padding: 22px; position: relative; z-index: 2; }
+.ch-domain-tag {
+  color: var(--cyan);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+}
+.ch-domain-body h3 {
+  margin: 8px 0 10px;
+  color: #fff;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+.ch-domain-body p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+.ch-corner {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  z-index: 4;
+  pointer-events: none;
+}
+.ch-corner-tl { top: 8px; left: 8px; border-top: 2px solid var(--lime); border-left: 2px solid var(--lime); }
+.ch-corner-br { bottom: 8px; right: 8px; border-bottom: 2px solid var(--lime); border-right: 2px solid var(--lime); }
+
+/* ==================== SHARED HORIZONTAL SCROLL ROW ==================== */
+.ch-hscroll {
+  display: flex;
+  gap: 22px;
+  overflow-x: auto;
+  /* explicit so overflow-x:auto doesn't coerce overflow-y to auto (stray v-scrollbar) */
+  overflow-y: hidden;
+  padding: 12px 4px 26px;
+  scroll-snap-type: x proximity;
+  /* hide the horizontal bar — this row still drags/swipes/wheel-scrolls (Netflix-style) */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+.ch-hscroll::-webkit-scrollbar {
+  display: none;
+}
+
+/* deck wrapper adds a right-edge fade + a drag/swipe cue under the row */
+.ch-deck { position: relative; }
+.ch-deck::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 34px;
+  right: 0;
+  width: 64px;
+  pointer-events: none;
+  z-index: 3;
+  background: linear-gradient(90deg, transparent, var(--bg-0) 92%);
+}
+.ch-deck-cue {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 6px;
+  padding-right: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.24em;
+  color: var(--cyan);
+  opacity: 0.85;
+}
+.ch-deck-arrows { display: inline-flex; gap: 4px; }
+.ch-deck-arrows i {
+  width: 6px;
+  height: 6px;
+  border-top: 1.5px solid var(--cyan);
+  border-right: 1.5px solid var(--cyan);
+  transform: rotate(45deg);
+  opacity: 0.35;
+  animation: ch-drag-arrow 1.2s ease-in-out infinite;
+}
+.ch-deck-arrows i:nth-child(2) { animation-delay: 0.15s; }
+.ch-deck-arrows i:nth-child(3) { animation-delay: 0.3s; }
+@keyframes ch-drag-arrow {
+  50% { opacity: 1; box-shadow: 1px -1px 6px rgba(61, 242, 255, 0.5); }
+}
+
+/* ============================ RECENT (redesigned cards) ============================ */
+.ch-recent-card {
+  scroll-snap-align: start;
+  flex: 0 0 min(360px, 84vw);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  background: var(--bg-2);
+  overflow: hidden;
+  transition: transform 0.15s ease, border-color 0.3s, box-shadow 0.3s;
+  transform-style: preserve-3d;
+}
+.ch-recent-card:hover {
+  border-color: var(--line-cyan);
+  box-shadow: var(--shadow-card);
+}
+.ch-recent-media {
+  position: relative;
+  width: 100%;
+  height: clamp(190px, 30vh, 240px);
+  overflow: hidden;
+  background: #05070a;
+}
+.ch-recent-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+  transition: transform 0.6s ease, filter 0.4s ease;
+  filter: saturate(1.05) contrast(1.03);
+}
+.ch-recent-card:hover .ch-recent-img { transform: scale(1.05); }
+/* faint scanline sheen so the images read as "feed frames", not raw photos */
+.ch-recent-scan {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, transparent 60%, rgba(5, 7, 10, 0.55)),
+    repeating-linear-gradient(to bottom, rgba(0,0,0,0) 0 2px, rgba(0,0,0,0.12) 3px, rgba(0,0,0,0) 4px);
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+.ch-recent-body {
+  padding: 18px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+.ch-recent-tag {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.2em;
+  color: var(--cyan);
+}
+.ch-recent-body h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+.ch-recent-body p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ch-recent-link {
+  margin-top: auto;
+  padding-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  color: var(--lime);
+  text-decoration: none;
+  transition: letter-spacing 0.2s ease, text-shadow 0.2s ease;
+}
+.ch-recent-link:hover {
+  letter-spacing: 0.24em;
+  text-shadow: var(--text-glow-lime);
+}
+.ch-recent-media .ch-corner-tl { top: 8px; left: 8px; }
+
+/* ============================ TEAM (responsive grid) ============================ */
+.ch-center { text-align: center; margin-top: 26px; }
+
+/* ============================ TEAM ============================ */
+.ch-team .team-section { padding-top: 0; }
+.ch-center { text-align: center; margin-top: 30px; }
+
+/* ============================ FINAL CTA ============================ */
+.ch-final {
+  text-align: center;
+  border-top: 1px solid var(--line);
+  overflow: hidden;
+  max-width: 100% !important;
+  background:
+    radial-gradient(60% 100% at 50% 100%, rgba(187, 223, 77, 0.1), transparent 70%),
+    var(--ink);
+}
+.ch-final-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 60px 60px;
+  transform: perspective(400px) rotateX(60deg);
+  transform-origin: bottom;
+  mask-image: linear-gradient(to top, black, transparent 70%);
+  -webkit-mask-image: linear-gradient(to top, black, transparent 70%);
+  opacity: 0.6;
+  animation: ch-grid-move 8s linear infinite;
+}
+.ch-final-title {
+  position: relative;
+  font-size: clamp(2.4rem, 7vw, 5.5rem);
+  font-weight: 700;
+  color: #fff;
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+.ch-final-sub {
+  position: relative;
+  color: var(--muted);
+  margin: 22px 0 34px;
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+}
+
+/* ==================== REUSABLE RGB-SPLIT GLITCH (headings) ==================== */
+.ch-glitch { position: relative; }
+.ch-glitch::before,
+.ch-glitch::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  clip-path: inset(0 0 0 0);
+}
+.ch-glitch::before {
+  color: var(--cyan);
+  mix-blend-mode: screen;
+  animation: ch-glitch-a 5s infinite steps(2);
+}
+.ch-glitch::after {
+  color: var(--lime);
+  mix-blend-mode: screen;
+  animation: ch-glitch-b 5s infinite steps(2);
+}
+@media (hover: hover) and (pointer: fine) {
+  .ch-glitch:hover::before,
+  .ch-glitch:hover::after { animation-duration: 0.55s; }
+}
+/* final-CTA title is two stacked glitch lines so each ghost layer registers */
+.ch-final-title .ch-glitch { display: block; }
+
+/* ==================== CAPABILITIES DECK ==================== */
+.ch-cap-card {
+  scroll-snap-align: start;
+  flex: 0 0 min(300px, 78vw);
+  position: relative;
+  padding: 26px 24px 22px;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(180deg, rgba(61, 242, 255, 0.04), transparent 60%),
+    var(--bg-2);
+  transition: transform 0.15s ease, border-color 0.3s, box-shadow 0.3s;
+  transform-style: preserve-3d;
+}
+.ch-cap-card:hover {
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-card);
+}
+.ch-cap-code {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: var(--cyan);
+}
+.ch-cap-card h3 {
+  margin: 12px 0 12px;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #fff;
+}
+.ch-cap-card p {
+  margin: 0 0 20px;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  min-height: 4.4em;
+}
+.ch-cap-link {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  color: var(--lime);
+  text-decoration: none;
+  transition: letter-spacing 0.2s ease, text-shadow 0.2s ease;
+}
+.ch-cap-link:hover {
+  letter-spacing: 0.24em;
+  text-shadow: var(--text-glow-lime);
+}
+
+/* ==================== DOMAIN CARD SHEEN SWEEP ==================== */
+.ch-domain-sheen {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: linear-gradient(120deg, transparent 42%, rgba(255, 255, 255, 0.14) 50%, transparent 58%);
+  transform: translateX(-120%);
+  opacity: 0;
+}
+.ch-domain-card:hover .ch-domain-sheen {
+  opacity: 1;
+  animation: ch-sheen 0.8s ease;
+}
+@keyframes ch-sheen { to { transform: translateX(120%); } }
+
+/* ==================== TEAM CARDS → dark cyber deck ==================== */
+/* the Card renders an empty <h2 class="section-title"> (title=""); hide it +
+   its off-brand green underline so it doesn't leave a gap in the cyber chapter */
+.ch-team .team-section { padding: 0 !important; }
+.ch-team .team-section .section-title { display: none; }
+/* roster is a responsive grid: 4-across → 2×2 → (narrow) 2-col, always one screen */
+.ch-team .team-grid {
+  display: grid !important;
+  grid-template-columns: repeat(4, 1fr) !important;
+  gap: clamp(14px, 2vw, 24px);
+  overflow: visible;
+  padding: 0;
+  margin: 0 auto;
+  max-width: 1100px;
+  width: 100%;
+}
+/* ---- coordinator cards: angular cyber HUD panels ---- */
+.ch-team .team-card {
+  position: relative;
+  background: linear-gradient(158deg, rgba(14, 20, 27, 0.96), rgba(8, 11, 17, 0.96)) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 0 !important;
+  /* cut top-right + bottom-left corners → angular, not a boring rounded box */
+  clip-path: polygon(0 0, calc(100% - 20px) 0, 100% 20px, 100% 100%, 20px 100%, 0 calc(100% - 20px)) !important;
+  color: var(--text) !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  animation: none !important;
+  transition: transform 0.32s var(--ease-out), border-color 0.3s var(--ease-out),
+    filter 0.3s var(--ease-out) !important;
+}
+/* corner-bracket reticles (::after repurposed from the old green wash).
+   NOTE: offsets must be !important per-side — a shared `inset: auto !important`
+   would expand to four important `auto`s that beat the non-important 9px
+   offsets below, dropping both brackets to their static positions (that's the
+   bug that put the cyan bracket at bottom-LEFT). */
+.ch-team .team-card::before,
+.ch-team .team-card::after {
+  content: "" !important;
+  position: absolute !important;
+  width: 15px !important;
+  height: 15px !important;
+  z-index: 3 !important;
+  display: block !important;
+  background: none !important;
+  opacity: 1 !important;
+  pointer-events: none !important;
+  transition: border-color 0.3s var(--ease-out) !important;
+}
+.ch-team .team-card::before {
+  top: 9px !important;
+  left: 9px !important;
+  right: auto !important;
+  bottom: auto !important;
+  border-top: 2px solid var(--lime);
+  border-left: 2px solid var(--lime);
+}
+.ch-team .team-card::after {
+  bottom: 9px !important;
+  right: 9px !important;
+  top: auto !important;
+  left: auto !important;
+  border-bottom: 2px solid var(--cyan);
+  border-right: 2px solid var(--cyan);
+}
+.ch-team .team-card:hover {
+  transform: translateY(-8px) !important;
+  border-color: var(--lime) !important;
+  filter: drop-shadow(0 16px 30px rgba(0, 0, 0, 0.55))
+    drop-shadow(0 0 16px rgba(187, 223, 77, 0.32)) !important;
+}
+.ch-team .team-card:hover::after {
+  border-bottom-color: var(--lime);
+  border-right-color: var(--lime);
+}
+
+/* avatar: rounded-square with a lime→cyan gradient frame (pops on dark) */
+.ch-team .image-wrapper {
+  width: clamp(88px, 13vh, 118px) !important;
+  height: clamp(88px, 13vh, 118px) !important;
+  margin: clamp(16px, 2.2vh, 26px) auto 12px !important;
+  border-radius: 14px !important;
+  border: 2px solid transparent !important;
+  background: linear-gradient(var(--bg-1), var(--bg-1)) padding-box,
+    linear-gradient(140deg, var(--lime), var(--cyan)) border-box !important;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.45) !important;
+  overflow: hidden !important;
+  transition: box-shadow 0.3s var(--ease-out), transform 0.3s var(--ease-out) !important;
+}
+.ch-team .team-image { border-radius: 12px !important; }
+.ch-team .team-card:hover .image-wrapper {
+  box-shadow: 0 0 24px rgba(187, 223, 77, 0.45), 0 8px 22px rgba(0, 0, 0, 0.45) !important;
+  transform: translateY(-2px) !important;
+}
+
+/* name + cyan HUD accent */
+.ch-team .team-content {
+  padding: 4px 14px clamp(12px, 1.8vh, 18px) !important;
+  position: relative;
+  z-index: 2;
+}
+.ch-team .member-name {
+  font-family: var(--font-sans) !important;
+  font-size: 1.05rem !important;
+  font-weight: 600 !important;
+  color: #fff !important;
+  margin-bottom: 8px !important;
+}
+
+/* social icons: outlined cyber chips — clear on dark, fill lime on hover */
+.ch-team .social-links {
+  margin-top: 8px !important;
+  gap: 10px !important;
+  min-height: 0 !important;
+}
+.ch-team .social-links a {
+  width: 36px !important;
+  height: 36px !important;
+  border-radius: 9px !important;
+  background: rgba(187, 223, 77, 0.08) !important;
+  border: 1px solid var(--line-strong) !important;
+  color: var(--lime) !important;
+  transition: background 0.2s var(--ease-out), color 0.2s var(--ease-out),
+    box-shadow 0.2s var(--ease-out), transform 0.2s var(--ease-out) !important;
+}
+.ch-team .social-links i { color: inherit !important; }
+.ch-team .team-card:hover .social-links a {
+  background: rgba(187, 223, 77, 0.14) !important;
+  color: var(--lime) !important;
+}
+.ch-team .social-links a:hover,
+.ch-team .team-card:hover .social-links a:hover {
+  background: var(--lime) !important;
+  color: var(--bg-0) !important;
+  box-shadow: var(--glow-lime-sm) !important;
+  transform: translateY(-2px) !important;
+}
+.ch-team .ch-section-head { margin-bottom: clamp(16px, 2.5vh, 34px); }
+
+/* LARGER cards on desktop — a single row of 4 has plenty of vertical room */
+@media (min-width: 901px) {
+  .ch-team .image-wrapper {
+    width: clamp(140px, 20vh, 182px) !important;
+    height: clamp(140px, 20vh, 182px) !important;
+    margin: 30px auto 16px !important;
+    border-radius: 16px !important;
+  }
+  .ch-team .team-image { border-radius: 14px !important; }
+  .ch-team .member-name { font-size: 1.24rem !important; }
+  .ch-team .social-links a { width: 40px !important; height: 40px !important; }
+  .ch-team .team-content { padding: 6px 18px 22px !important; }
+  .ch-team .team-card::before,
+  .ch-team .team-card::after { width: 18px !important; height: 18px !important; }
+}
+@media (max-width: 900px) {
+  .ch-team .team-grid { grid-template-columns: repeat(2, 1fr) !important; }
+}
+
+/* ==================== KONAMI · OVERCLOCK ==================== */
+.ch-overclock {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+.ch-overclock-toast {
+  margin-top: calc(var(--nav-h) + 24px);
+  font-family: var(--font-mono);
+  letter-spacing: 0.35em;
+  color: var(--magenta);
+  border: 1px solid var(--magenta);
+  padding: 10px 22px;
+  background: rgba(0, 0, 0, 0.65);
+  box-shadow: 0 0 30px rgba(255, 77, 157, 0.5);
+  animation: ch-oc-flicker 0.3s steps(2) infinite;
+}
+@keyframes ch-oc-flicker { 50% { opacity: 0.55; } }
+[data-overclock="on"] .ch-canvas canvas {
+  filter: hue-rotate(55deg) saturate(1.7) contrast(1.12);
+}
+
+/* ============================ RESPONSIVE ============================ */
+/* small laptops / tablet-landscape */
+@media (max-width: 1024px) {
+  .ch-hud-tl, .ch-hud-tr { top: 76px; }
+}
+@media (max-width: 900px) {
+  /* single-column About + hide the decorative terminal so the chapter fits one screen */
+  .ch-about-grid { grid-template-columns: 1fr; }
+  .ch-about-side { display: none; }
+  .ch-about-panel { max-height: 66svh; }
+}
+/* tablet portrait */
+@media (max-width: 768px) {
+  .ch-section-head { margin-bottom: 32px; }
+}
+/* phone portrait */
+@media (max-width: 620px) {
+  .ch-root section { padding: 76px 18px; }
+  .ch-hud-bl, .ch-hud-br { display: none; }
+  /* shrink the hero wordmark so "ELECTRONICS" never overflows a narrow screen */
+  .ch-title { font-size: clamp(1.7rem, 9vw, 3rem); letter-spacing: 0; }
+  .ch-hero-content { padding: 0 16px; }
+  /* a soft dark bloom so text stays legible over the bright reactor core */
+  .ch-hero-content::before {
+    content: "";
+    position: absolute;
+    inset: -8% -6%;
+    z-index: -1;
+    background: radial-gradient(ellipse at center, rgba(5, 7, 10, 0.72), transparent 72%);
+  }
+  .ch-tagline { gap: 6px 8px; letter-spacing: 0.16em; font-size: 0.72rem; }
+  .ch-eyebrow { font-size: 0.66rem; letter-spacing: 0.28em !important; word-break: break-word; }
+  .ch-cta-row { flex-direction: column; align-items: stretch; }
+  .ch-cta-row .mag { width: 100%; }
+  .ch-cta-row .ch-btn { display: block; text-align: center; }
+  .ch-about-panel { padding: 26px 22px; }
+  .ch-final-title { font-size: clamp(2rem, 10vw, 3.4rem); }
+}
+@media (max-width: 420px) {
+  .ch-hud-tl, .ch-hud-tr { font-size: 0.6rem; top: 72px; }
+  .ch-title { font-size: clamp(1.55rem, 8.5vw, 2.4rem); }
+}
+
+/* SHORT VIEWPORT (landscape phones/tablets): unsnap + let content flow/scroll */
+@media (max-height: 600px) and (orientation: landscape) {
+  html.home-snap { scroll-snap-type: none; }
+  .ch-hero {
+    height: auto;
+    min-height: 100svh;
+    scroll-snap-align: none;
+    scroll-snap-stop: normal;
+    padding: 84px 0 44px;
+  }
+  .ch-chapter {
+    min-height: auto;
+    height: auto;
+    overflow: visible;
+    scroll-snap-align: none;
+    scroll-snap-stop: normal;
+    justify-content: flex-start;
+    padding-block: 54px;
+  }
+  .ch-about-panel { max-height: none; overflow: visible; }
+  .ch-scroll-cue { display: none; }
+  .ch-hud { display: none; }
+  .ch-title { font-size: clamp(1.9rem, 6.5vw, 3rem); }
+  .ch-tagline { margin: 14px 0 20px; }
+}
+
+/* respect reduced motion — static page that flows/scrolls normally */
+@media (prefers-reduced-motion: reduce) {
+  html.home-snap { scroll-snap-type: none; }
+  .ch-chapter {
+    height: auto;
+    min-height: 100svh;
+    overflow: visible;
+  }
+  .ch-about-panel { max-height: none; overflow: visible; }
+  .ch-root *,
+  .ch-root *::before,
+  .ch-root *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/Components/cyber/CyberHome.js
+++ b/src/Components/cyber/CyberHome.js
@@ -1,0 +1,740 @@
+import React, {
+  Suspense,
+  lazy,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Link } from "react-router-dom";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useInView,
+  useReducedMotion,
+} from "framer-motion";
+import { Card } from "../Team";
+import data from "../../database/data.json";
+import CircuitBG from "./CircuitBG";
+import Cursor, { Magnetic } from "./Cursor";
+import ScrollHUD from "./ScrollHUD";
+import BootSequence from "./BootSequence";
+import "./CyberHome.css";
+
+const Reactor = lazy(() => import("./Reactor"));
+
+/* ------------------------------------------------------------------ */
+/*  Small building blocks                                             */
+/* ------------------------------------------------------------------ */
+
+/* Character-by-character scramble reveal for the hero title */
+function GlitchTitle({ text }) {
+  const reduce = useReducedMotion();
+  const [display, setDisplay] = useState(reduce ? text : text);
+  const glyphs = "ABCDEFGHIJKLMNOPQRSTUVWXYZ<>/{}#01*+=_";
+  useEffect(() => {
+    if (reduce) {
+      setDisplay(text);
+      return undefined;
+    }
+    let frame = 0;
+    const total = 46;
+    const id = setInterval(() => {
+      frame++;
+      setDisplay(
+        text
+          .split("")
+          .map((ch, i) => {
+            if (ch === " ") return " ";
+            if (frame > total * (i / text.length) + 8) return ch;
+            return glyphs[Math.floor((frame * (i + 3)) % glyphs.length)];
+          })
+          .join("")
+      );
+      if (frame > total + 8) {
+        setDisplay(text);
+        clearInterval(id);
+      }
+    }, 45);
+    return () => clearInterval(id);
+  }, [text, reduce]);
+  return (
+    <h1 className="ch-title" data-text={text}>
+      {display}
+    </h1>
+  );
+}
+
+/* Section heading with the reusable RGB-split glitch skin */
+function GlitchH2({ text, plain, children }) {
+  return (
+    <h2 className="ch-h2 ch-glitch" data-text={plain || text}>
+      {children || text}
+    </h2>
+  );
+}
+
+/* "drag / swipe" affordance for horizontally-scrollable card decks */
+function DragCue() {
+  return (
+    <div className="ch-deck-cue" aria-hidden="true">
+      <span className="ch-deck-cue-label">DRAG · SWIPE</span>
+      <span className="ch-deck-arrows">
+        <i />
+        <i />
+        <i />
+      </span>
+    </div>
+  );
+}
+
+/* Generic scroll reveal wrapper.
+   `cut` upgrades it to a masked "slide-up". Static under reduced-motion. */
+function Reveal({ children, delay = 0, y = 40, className = "", cut = false }) {
+  const ref = useRef(null);
+  const reduce = useReducedMotion();
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+  if (reduce) {
+    return <div className={className}>{children}</div>;
+  }
+  if (cut) {
+    return (
+      <div ref={ref} className={`ch-cut ${className}`}>
+        <motion.div
+          initial={{ y: "115%" }}
+          animate={inView ? { y: "0%" } : { y: "115%" }}
+          transition={{ duration: 0.85, delay, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {children}
+        </motion.div>
+      </div>
+    );
+  }
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-60px" }}
+      transition={{ duration: 0.7, delay, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+const FINE_POINTER =
+  typeof window !== "undefined" &&
+  window.matchMedia &&
+  window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+/* Card that tilts toward the cursor — inert on touch/coarse pointers */
+function TiltCard({ children, className = "" }) {
+  const ref = useRef(null);
+  const [style, setStyle] = useState({});
+  if (!FINE_POINTER) {
+    return <div className={className}>{children}</div>;
+  }
+  const onMove = (e) => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const px = (e.clientX - r.left) / r.width - 0.5;
+    const py = (e.clientY - r.top) / r.height - 0.5;
+    setStyle({
+      transform: `perspective(700px) rotateY(${px * 10}deg) rotateX(${
+        -py * 10
+      }deg) translateZ(6px)`,
+      "--mx": `${(px + 0.5) * 100}%`,
+      "--my": `${(py + 0.5) * 100}%`,
+    });
+  };
+  const reset = () =>
+    setStyle({ transform: "perspective(700px) rotateY(0) rotateX(0)" });
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={style}
+      onMouseMove={onMove}
+      onMouseLeave={reset}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* Full-viewport "chapter". With mandatory full-page snap each section is one
+   screen, so the transition is a gentle dim + scale during the snap glide (no
+   y-translate — that would fight the snap alignment). Static under reduced-motion. */
+function ScrollSection({ children, className = "", id, stop = "always" }) {
+  const ref = useRef(null);
+  const reduce = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const opacity = useTransform(scrollYProgress, [0, 0.32, 0.68, 1], [0.35, 1, 1, 0.35]);
+  const scale = useTransform(scrollYProgress, [0, 0.32, 0.68, 1], [0.975, 1, 1, 0.975]);
+  if (reduce) {
+    return (
+      <section ref={ref} id={id} className={`ch-chapter ${className}`}>
+        <div className="ch-chapter-inner">{children}</div>
+      </section>
+    );
+  }
+  return (
+    <section
+      ref={ref}
+      id={id}
+      className={`ch-chapter ${className}`}
+      style={{ scrollSnapStop: stop }}
+    >
+      <motion.div className="ch-chapter-inner" style={{ opacity, scale }}>
+        {children}
+      </motion.div>
+    </section>
+  );
+}
+
+const pad = (n) => String(n).padStart(2, "0");
+
+/* Live HUD corner readouts — isolated component so its per-second ticks
+   re-render only these four labels, not the whole page. Pauses when hidden. */
+function HeroHud({ reduce }) {
+  const [uptime, setUptime] = useState(0);
+  const [fps, setFps] = useState(60);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!document.hidden) setUptime((u) => u + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    if (reduce) return undefined;
+    let raf;
+    let last = performance.now();
+    let frames = 0;
+    let acc = 0;
+    const loop = (now) => {
+      if (document.hidden) {
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+      frames++;
+      acc += now - last;
+      last = now;
+      if (acc >= 500) {
+        setFps(Math.min(120, Math.round((frames * 1000) / acc)));
+        frames = 0;
+        acc = 0;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [reduce]);
+
+  const upStr = `${pad(Math.floor(uptime / 60))}:${pad(uptime % 60)}`;
+  return (
+    <>
+      <div className="ch-hud ch-hud-tl">SYS // ONLINE</div>
+      <div className="ch-hud ch-hud-tr">IIT KANPUR · 26.5°N</div>
+      <div className="ch-hud ch-hud-bl">UPTIME {upStr}</div>
+      <div className="ch-hud ch-hud-br">{fps} FPS · NODES 12/12</div>
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Data                                                              */
+/* ------------------------------------------------------------------ */
+
+const CAPABILITIES = [
+  { code: "0x01", title: "Computer Vision", desc: "Teaching machines to see — object detection, tracking and real-time image processing on the edge." },
+  { code: "0x02", title: "Signal Processing & ML", desc: "Turning raw signals and data into intelligence with DSP and machine learning." },
+  { code: "0x03", title: "FPGA", desc: "Reconfigurable hardware and high-speed digital logic for serious parallel compute." },
+  { code: "0x04", title: "Embedded & IoT", desc: "Microcontrollers, sensors and connected devices that bridge the physical and digital worlds." },
+  { code: "0x05", title: "PCB", desc: "Designing, routing and fabricating custom circuit boards that actually ship." },
+];
+
+const DOMAINS = [
+  { img: "project.jpg", title: "Projects", tag: "// SUMMER_BUILD", desc: "Every year the club runs projects during summer under the Science & Technology Council." },
+  { img: "workshop.jpg", title: "Workshops", tag: "// HANDS_ON", desc: "Workshops across the year giving hands-on experience in a range of fields." },
+  { img: "techkriti.jpg", title: "Techkriti", tag: "// TECH_FEST", desc: "The club powers the annual Technological & Entrepreneurial festival of IIT Kanpur." },
+  { img: "takneek.jpg", title: "Takneek", tag: "// INTER_HALL", desc: "Every hall competes with one aim in mind — winning the coveted Takneek trophy." },
+  { img: "wintercamp.png", title: "Winter Camp", tag: "// DEEP_DIVE", desc: "An immersive program blending hands-on workshops with lectures on electronics." },
+  { img: "competitions/lam_onsite.jpeg", title: "Competitions", tag: "// GLOBAL", desc: "Won across International, National and Pan-IIT level competitions." },
+];
+
+const SECTIONS = [
+  { id: "sec-hero", code: "00", label: "BOOT" },
+  { id: "sec-recent", code: "01", label: "LIVE_FEED" },
+  { id: "sec-domains", code: "02", label: "ACTIVITIES" },
+  { id: "sec-cap", code: "03", label: "DOMAINS" },
+  { id: "sec-team", code: "04", label: "HUMANS" },
+  { id: "sec-about", code: "05", label: "WHO_WE_ARE" },
+  { id: "sec-final", code: "06", label: "JOIN" },
+];
+
+const KONAMI = [
+  "ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown",
+  "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight", "b", "a",
+];
+
+const SHEET_ID = "1kjMgQEFPqU8fOqCGaBUk75AQ_4ZymVfo8AwQNh0KpO8";
+const API_KEY = "AIzaSyB0KLQPuV6Ud6-d8e_dP-68ODNU_F2ULGA";
+const RANGE = "Sheet1!A2:D";
+
+/* ------------------------------------------------------------------ */
+/*  Main component                                                    */
+/* ------------------------------------------------------------------ */
+
+export default function CyberHome() {
+  const reduce = useReducedMotion();
+  const heroRef = useRef(null);
+  const { scrollYProgress } = useScroll({
+    target: heroRef,
+    offset: ["start start", "end start"],
+  });
+  const heroContentY = useTransform(scrollYProgress, [0, 1], [0, 140]);
+  const heroFade = useTransform(scrollYProgress, [0, 0.7], [1, 0]);
+
+  const [activities, setActivities] = useState([]);
+  const [showMore, setShowMore] = useState(false);
+  const [overclock, setOverclock] = useState(false);
+
+  // first-load boot sequence (once per tab session)
+  const [booted, setBooted] = useState(
+    () =>
+      typeof window === "undefined" ||
+      sessionStorage.getItem("nb_booted") === "1"
+  );
+
+  // gate the heavy 3D reactor: only render frames while the hero is on-screen
+  // AND the tab is visible (saves GPU/battery once you scroll past it)
+  const [reactorActive, setReactorActive] = useState(true);
+
+  // recent activities (Google Sheet) — guarded against set-after-unmount
+  useEffect(() => {
+    let alive = true;
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(
+          `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`,
+          { signal: ctrl.signal }
+        );
+        const d = await res.json();
+        if (alive && d.values) {
+          setActivities(
+            d.values.map((r) => ({
+              eventName: r[0],
+              imageUrl: r[1],
+              description: r[2],
+              link: r[3],
+            }))
+          );
+        }
+      } catch (e) {
+        /* silent — section simply stays empty */
+      }
+    })();
+    return () => {
+      alive = false;
+      ctrl.abort();
+    };
+  }, []);
+
+  // scope scroll-snap to the home route only (avoid leaking to other pages)
+  useEffect(() => {
+    document.documentElement.classList.add("home-snap");
+    return () => document.documentElement.classList.remove("home-snap");
+  }, []);
+
+  // drive reactor on/off from hero visibility + tab visibility
+  useEffect(() => {
+    const hero = heroRef.current;
+    let onScreen = true;
+    const sync = () =>
+      setReactorActive(onScreen && !document.hidden);
+    const io =
+      hero && "IntersectionObserver" in window
+        ? new IntersectionObserver(
+            ([e]) => {
+              onScreen = e.isIntersecting;
+              sync();
+            },
+            { threshold: 0.01 }
+          )
+        : null;
+    if (io && hero) io.observe(hero);
+    document.addEventListener("visibilitychange", sync);
+    return () => {
+      if (io) io.disconnect();
+      document.removeEventListener("visibilitychange", sync);
+    };
+  }, []);
+
+  // Konami → OVERCLOCK
+  useEffect(() => {
+    let idx = 0;
+    let timer;
+    const onKey = (e) => {
+      const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+      idx = key === KONAMI[idx] ? idx + 1 : key === KONAMI[0] ? 1 : 0;
+      if (idx === KONAMI.length) {
+        idx = 0;
+        setOverclock(true);
+        document.documentElement.dataset.overclock = "on";
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          setOverclock(false);
+          delete document.documentElement.dataset.overclock;
+        }, 5000);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      clearTimeout(timer);
+      delete document.documentElement.dataset.overclock;
+    };
+  }, []);
+
+  const finishBoot = () => {
+    try {
+      sessionStorage.setItem("nb_booted", "1");
+    } catch (e) {
+      /* ignore */
+    }
+    setBooted(true);
+  };
+
+  return (
+    <>
+      {!booted && <BootSequence onFinish={finishBoot} />}
+
+      <div className="ch-root">
+        <CircuitBG />
+        <Cursor />
+        <ScrollHUD sections={SECTIONS} />
+
+        {overclock && (
+          <div className="ch-overclock" aria-hidden="true">
+            <span className="ch-overclock-toast">MODE // OVERCLOCK</span>
+          </div>
+        )}
+
+        {/* ============================ HERO ============================ */}
+        <section className="ch-hero" id="sec-hero" ref={heroRef}>
+          <div className="ch-canvas" aria-hidden="true">
+            {reduce ? (
+              <div className="ch-canvas-fallback" />
+            ) : (
+              <Suspense fallback={<div className="ch-canvas-fallback" />}>
+                <Reactor active={reactorActive} />
+              </Suspense>
+            )}
+          </div>
+
+          <div className="ch-grid-overlay" />
+          <div className="ch-scanlines" />
+          <div className="ch-vignette" />
+
+          {/* live HUD corners (isolated so its ticks don't re-render the page) */}
+          <HeroHud reduce={reduce} />
+
+          <motion.div
+            className="ch-hero-content"
+            style={reduce ? undefined : { y: heroContentY, opacity: heroFade }}
+          >
+            <motion.p
+              className="ch-eyebrow"
+              initial={{ opacity: 0, letterSpacing: "0.1em" }}
+              animate={{ opacity: 1, letterSpacing: "0.5em" }}
+              transition={{ duration: 1.2, delay: 0.2 }}
+            >
+              &gt; INITIALIZING_ELECTRONICS_CLUB
+            </motion.p>
+
+            <GlitchTitle text="ELECTRONICS CLUB" />
+
+            <motion.p
+              className="ch-tagline"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 1.1 }}
+            >
+              <span>INNOVATION</span>
+              <span className="ch-dot">·</span>
+              <span>IMAGINATION</span>
+              <span className="ch-dot">·</span>
+              <span>APPLICATION</span>
+            </motion.p>
+
+            <motion.div
+              className="ch-cta-row"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 1.35 }}
+            >
+              <Magnetic>
+                <Link to="/Projects" className="ch-btn ch-btn-primary">
+                  <span>EXPLORE PROJECTS</span>
+                </Link>
+              </Magnetic>
+              <Magnetic>
+                <Link to="/Team" className="ch-btn ch-btn-ghost">
+                  <span>MEET THE TEAM</span>
+                </Link>
+              </Magnetic>
+            </motion.div>
+          </motion.div>
+
+          <motion.div
+            className="ch-scroll-cue"
+            style={reduce ? undefined : { opacity: heroFade }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.8 }}
+          >
+            <span>SCROLL</span>
+            <div className="ch-scroll-track">
+              <div className="ch-scroll-dot" />
+            </div>
+          </motion.div>
+
+        </section>
+
+        {/* ========================= RECENT ACTIVITIES ========================= */}
+        {activities.length > 0 && (
+          <ScrollSection className="ch-recent" id="sec-recent">
+            <Reveal cut className="ch-section-head">
+              <span className="ch-kicker">01_FEED · live feed</span>
+              <GlitchH2 text="Recent Activities" />
+            </Reveal>
+            <div className="ch-deck">
+              <div className="ch-hscroll ch-recent-scroll">
+                {activities.map((a, i) => (
+                  <TiltCard key={i} className="ch-recent-card">
+                    <div className="ch-recent-media">
+                      <img
+                        className="ch-recent-img"
+                        src={a.imageUrl}
+                        alt={a.eventName || "Recent activity"}
+                        loading="lazy"
+                      />
+                      <span className="ch-recent-scan" />
+                      <span className="ch-corner ch-corner-tl" />
+                    </div>
+                    <div className="ch-recent-body">
+                      <span className="ch-recent-tag">{'// EVENT_LOG'}</span>
+                      <h3>{a.eventName}</h3>
+                      <p>{a.description}</p>
+                      {a.link && (
+                        <a
+                          href={a.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ch-recent-link"
+                        >
+                          VIEW MORE →
+                        </a>
+                      )}
+                    </div>
+                  </TiltCard>
+                ))}
+              </div>
+              <DragCue />
+            </div>
+          </ScrollSection>
+        )}
+
+        {/* ========================= ACTIVITIES ========================= */}
+        <ScrollSection className="ch-domains" id="sec-domains">
+          <Reveal cut className="ch-section-head">
+            <span className="ch-kicker">02_ACTIVITIES · what we do</span>
+            <GlitchH2 text="Club Activities" />
+          </Reveal>
+
+          <div className="ch-deck">
+            <div className="ch-hscroll ch-domain-scroll">
+              {DOMAINS.map((d) => (
+                <TiltCard key={d.title} className="ch-domain-card">
+                  <div className="ch-domain-glow" />
+                  <span className="ch-domain-sheen" />
+                  <div
+                    className="ch-domain-img"
+                    style={{ backgroundImage: `url(/images/${d.img})` }}
+                  />
+                  <div className="ch-domain-body">
+                    <span className="ch-domain-tag">{d.tag}</span>
+                    <h3>{d.title}</h3>
+                    <p>{d.desc}</p>
+                  </div>
+                  <span className="ch-corner ch-corner-tl" />
+                  <span className="ch-corner ch-corner-br" />
+                </TiltCard>
+              ))}
+            </div>
+            <DragCue />
+          </div>
+        </ScrollSection>
+
+        {/* ============================ DOMAINS ============================ */}
+        <ScrollSection className="ch-cap" id="sec-cap">
+          <Reveal cut className="ch-section-head">
+            <span className="ch-kicker">03_DOMAINS · what we work on</span>
+            <GlitchH2 text="Domains" />
+          </Reveal>
+          <div className="ch-deck">
+            <div className="ch-hscroll ch-cap-scroll">
+              {CAPABILITIES.map((c) => (
+                <TiltCard key={c.code} className="ch-cap-card">
+                  <span className="ch-corner ch-corner-tl" />
+                  <span className="ch-corner ch-corner-br" />
+                  <span className="ch-cap-code">{c.code}</span>
+                  <h3>{c.title}</h3>
+                  <p>{c.desc}</p>
+                  <Link to="/Projects" className="ch-cap-link">
+                    VIEW BUILDS →
+                  </Link>
+                </TiltCard>
+              ))}
+            </div>
+            <DragCue />
+          </div>
+        </ScrollSection>
+
+        {/* ============================ TEAM ============================ */}
+        <ScrollSection className="ch-team" id="sec-team">
+          <Reveal cut className="ch-section-head">
+            <span className="ch-kicker">04_HUMANS · the people</span>
+            <GlitchH2 text="Meet the Coordinators" />
+          </Reveal>
+          <Reveal delay={0.1}>
+            <Card title="" items={data.coordi} />
+          </Reveal>
+          <Reveal className="ch-center" delay={0.15}>
+            <Magnetic>
+              <Link to="/Team" className="ch-btn ch-btn-primary">
+                <span>KNOW OUR FULL TEAM</span>
+              </Link>
+            </Magnetic>
+          </Reveal>
+        </ScrollSection>
+
+        {/* ============================ ABOUT ============================ */}
+        <ScrollSection className="ch-about" id="sec-about">
+          <Reveal cut className="ch-section-head">
+            <span className="ch-kicker">05_WHO · who we are</span>
+            <GlitchH2 plain="Turning ideas into reality">
+              Turning <span className="ch-hl">ideas</span> into{" "}
+              <span className="ch-hl">reality</span>
+            </GlitchH2>
+          </Reveal>
+
+          <div className="ch-about-grid">
+            <Reveal className="ch-about-panel" delay={0.05}>
+              <p>
+                Electronics Club, earlier started as a hobby group, has now
+                expanded into a students' organisation with the objective of
+                inculcating a spirit of developing innovative, cutting-edge
+                technology solutions to real-life problems.
+              </p>
+              <p className="ch-lime">
+                We provide a platform where any individual with an idea can
+                approach the club freely to grasp the technical skills required
+                to turn that idea into a reality.
+              </p>
+
+              {showMore && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  transition={{ duration: 0.5 }}
+                >
+                  <h4 className="ch-sub">What We Provide</h4>
+                  <p>
+                    A place where students think outside the academic curriculum
+                    and get practical experience by applying concepts from
+                    theoretical courses — through lectures, workshops, projects
+                    and competitions across analog and digital electronics.
+                  </p>
+                  <h4 className="ch-sub">About Our Projects</h4>
+                  <p>
+                    Our summer projects are a stepping stone for many freshers,
+                    spanning embedded systems &amp; IoT, VLSI, signal processing,
+                    ML and AI. We have taken up industrial projects from
+                    organisations like DRDO, BARC, BARC INDIA and BETIC.
+                  </p>
+                  <Link to="/Projects" className="ch-btn ch-btn-primary ch-inline">
+                    <span>LEARN MORE</span>
+                  </Link>
+                </motion.div>
+              )}
+
+              <button
+                className="ch-readmore"
+                onClick={() => setShowMore((v) => !v)}
+              >
+                {showMore ? "− READ LESS" : "+ READ MORE"}
+              </button>
+            </Reveal>
+
+            <Reveal className="ch-about-side" delay={0.15}>
+              <div className="ch-terminal">
+                <div className="ch-term-bar">
+                  <i /> <i /> <i /> <span>eclub@iitk: ~</span>
+                </div>
+                <pre>
+{`$ ./club --status
+> domains ......... [ 6 active ]
+> mode ............ INNOVATE
+> workshops ....... RUNNING
+> projects ........ DEPLOYED
+> mission ......... "build the future"
+
+_ ready for input`}
+                </pre>
+              </div>
+            </Reveal>
+          </div>
+        </ScrollSection>
+
+        {/* ============================ FINAL CTA ============================ */}
+        <ScrollSection className="ch-final" id="sec-final">
+          <div className="ch-final-grid" />
+          <Reveal>
+            <h2 className="ch-final-title">
+              <span className="ch-glitch" data-text="READY TO BUILD">
+                READY TO BUILD
+              </span>
+              <span className="ch-glitch" data-text="THE FUTURE?">
+                THE <span className="ch-hl">FUTURE?</span>
+              </span>
+            </h2>
+            <p className="ch-final-sub">
+              Bring an idea. Leave with the skills to build it.
+            </p>
+            <div className="ch-cta-row ch-center">
+              <Magnetic>
+                <Link to="/Comp" className="ch-btn ch-btn-primary">
+                  <span>GET COMPONENTS</span>
+                </Link>
+              </Magnetic>
+              <Magnetic>
+                <Link to="/Challenge" className="ch-btn ch-btn-ghost">
+                  <span>MONTHLY CHALLENGE</span>
+                </Link>
+              </Magnetic>
+            </div>
+          </Reveal>
+        </ScrollSection>
+      </div>
+    </>
+  );
+}

--- a/src/Components/cyber/Reactor.js
+++ b/src/Components/cyber/Reactor.js
@@ -1,0 +1,169 @@
+import React, { useRef, useMemo } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import {
+  Icosahedron,
+  Torus,
+  MeshDistortMaterial,
+  Sparkles,
+  Float,
+  Environment,
+} from "@react-three/drei";
+import * as THREE from "three";
+
+const LIME = "#bbdf4d";
+const CYAN = "#3df2ff";
+
+/* device tier — downgrade the scene on phones / touch for perf + battery */
+const mq = (q) =>
+  typeof window !== "undefined" && window.matchMedia
+    ? window.matchMedia(q).matches
+    : false;
+const IS_MOBILE = mq("(max-width: 640px)");
+const FINE_POINTER = mq("(hover: hover) and (pointer: fine)");
+const NODE_COUNT = IS_MOBILE ? 8 : 14;
+
+/* Central pulsing distorted core */
+function Core() {
+  const mat = useRef();
+  useFrame(({ clock }) => {
+    if (mat.current) {
+      mat.current.distort = 0.35 + Math.sin(clock.elapsedTime * 1.5) * 0.12;
+    }
+  });
+  return (
+    <Icosahedron args={[1.15, 4]}>
+      <MeshDistortMaterial
+        ref={mat}
+        color={LIME}
+        emissive={LIME}
+        emissiveIntensity={0.35}
+        roughness={0.15}
+        metalness={0.9}
+        distort={0.4}
+        speed={2}
+      />
+    </Icosahedron>
+  );
+}
+
+/* Wireframe shell that rotates around the core */
+function Shell() {
+  const ref = useRef();
+  useFrame((_, delta) => {
+    if (ref.current) {
+      ref.current.rotation.y += delta * 0.25;
+      ref.current.rotation.x += delta * 0.12;
+    }
+  });
+  return (
+    <Icosahedron ref={ref} args={[1.85, 1]}>
+      <meshBasicMaterial color={LIME} wireframe transparent opacity={0.28} />
+    </Icosahedron>
+  );
+}
+
+/* Orbiting neon rings */
+function Rings() {
+  const g = useRef();
+  useFrame((_, delta) => {
+    if (g.current) g.current.rotation.z += delta * 0.4;
+  });
+  return (
+    <group ref={g}>
+      <Torus args={[2.6, 0.015, 16, 120]} rotation={[Math.PI / 2.2, 0, 0]}>
+        <meshBasicMaterial color={CYAN} transparent opacity={0.65} />
+      </Torus>
+      <Torus args={[3.1, 0.01, 16, 120]} rotation={[Math.PI / 1.7, 0.5, 0]}>
+        <meshBasicMaterial color={LIME} transparent opacity={0.5} />
+      </Torus>
+      <Torus args={[3.6, 0.008, 16, 120]} rotation={[Math.PI / 2.6, -0.6, 0.4]}>
+        <meshBasicMaterial color={CYAN} transparent opacity={0.35} />
+      </Torus>
+    </group>
+  );
+}
+
+/* Small nodes orbiting like electrons */
+function Electrons() {
+  const g = useRef();
+  const nodes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < NODE_COUNT; i++) {
+      const a = (i / 14) * Math.PI * 2;
+      const r = 2.6 + (i % 3) * 0.5;
+      arr.push({
+        a,
+        r,
+        y: (Math.sin(i) * 1.2),
+        s: 0.03 + (i % 3) * 0.015,
+      });
+    }
+    return arr;
+  }, []);
+  useFrame(({ clock }) => {
+    if (!g.current) return;
+    const t = clock.elapsedTime;
+    g.current.children.forEach((m, i) => {
+      const n = nodes[i];
+      m.position.x = Math.cos(n.a + t * 0.5) * n.r;
+      m.position.z = Math.sin(n.a + t * 0.5) * n.r;
+      m.position.y = n.y + Math.sin(t + i) * 0.3;
+    });
+  });
+  return (
+    <group ref={g}>
+      {nodes.map((n, i) => (
+        <mesh key={i}>
+          <sphereGeometry args={[n.s, 12, 12]} />
+          <meshBasicMaterial color={i % 2 ? CYAN : LIME} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Rotate whole rig toward pointer for parallax (fine pointers only —
+   on touch the pointer sticks at the last tap and skews the rig) */
+function Rig({ children }) {
+  const g = useRef();
+  useFrame((state) => {
+    if (!g.current) return;
+    if (FINE_POINTER) {
+      const { x, y } = state.pointer;
+      g.current.rotation.y = THREE.MathUtils.lerp(g.current.rotation.y, x * 0.4, 0.05);
+      g.current.rotation.x = THREE.MathUtils.lerp(g.current.rotation.x, -y * 0.3, 0.05);
+    } else {
+      // gentle idle drift instead of pointer-follow
+      g.current.rotation.y = THREE.MathUtils.lerp(g.current.rotation.y, 0, 0.02);
+      g.current.rotation.x = THREE.MathUtils.lerp(g.current.rotation.x, 0, 0.02);
+    }
+  });
+  return <group ref={g}>{children}</group>;
+}
+
+export default function Reactor({ active = true }) {
+  return (
+    <Canvas
+      // pause the render loop when the hero is offscreen / tab hidden (battery + GPU)
+      frameloop={active ? "always" : "never"}
+      dpr={[1, IS_MOBILE ? 1.5 : 2]}
+      camera={{ position: [0, 0, 7.5], fov: 45 }}
+      gl={{ antialias: !IS_MOBILE, alpha: true, powerPreference: "high-performance" }}
+    >
+      <ambientLight intensity={0.4} />
+      <pointLight position={[5, 5, 5]} intensity={2} color={LIME} />
+      <pointLight position={[-5, -3, 2]} intensity={1.5} color={CYAN} />
+      <Rig>
+        <Float speed={2} rotationIntensity={0.6} floatIntensity={0.8}>
+          <Core />
+          <Shell />
+        </Float>
+        <Rings />
+        <Electrons />
+        <Sparkles count={IS_MOBILE ? 40 : 90} scale={9} size={2.2} speed={0.4} color={LIME} opacity={0.7} />
+        <Sparkles count={IS_MOBILE ? 22 : 50} scale={12} size={1.4} speed={0.2} color={CYAN} opacity={0.5} />
+      </Rig>
+      <Environment preset="night" />
+    </Canvas>
+  );
+}


### PR DESCRIPTION
## What this does
The new landing experience (`CyberHome`), replacing the old homepage.

- **Boot sequence** — terminal-style boot plays once per tab session (sessionStorage-gated), then never again.
- **Hero** — lazy-loaded 3D reactor (three.js via @react-three/fiber) behind a scramble-reveal title, HUD corner readouts (uptime/FPS), and magnetic CTAs. The reactor only renders frames while the hero is on-screen AND the tab is visible — it costs nothing once you scroll past it.
- **Chapters** — full-page scroll-snap sections in order: Recent Activities (live Google-Sheet feed; the section hides itself if the sheet is empty) → Club Activities → Domains → Meet the Coordinators (reuses the Team page's Card component, restyled via `.ch-team` overrides) → Who We Are → final CTA. Scroll-snap is scoped to the home route only and cleaned up on unmount.
- **ScrollHUD** wired with the section list; horizontal card decks have tilt-on-hover and drag cues.
- Konami-code easter egg (OVERCLOCK mode, 5s).

## Review notes
- Everything renders statically under `prefers-reduced-motion` (no snap, no 3D, no glitch).
- The Recent Activities feed fails silent (section simply absent) if the sheet fetch errors.

---
**Series notes** (part of a 14-PR redesign, preview: https://eclub-beta.netlify.app): every PR touches a disjoint set of files, so they merge conflict-free in any order (recommended: 01 → 14). The site builds only once the whole series is in. Nothing deploys to the live site until `npm run deploy` is run after the series lands.