### PR TITLE
Navbar and footer: cyber restyle with the EClub mark as the site logo

### DIFF
--- a/src/Components/Footer.css
+++ b/src/Components/Footer.css
@@ -1,0 +1,399 @@
+/* =========================
+   BASE CYBER FOOTER
+========================= */
+.footer-cyber {
+  position: relative;
+  margin-top: 60px;
+  padding: 70px 20px 20px;
+
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(20px);
+
+  color: var(--lime);
+
+  /* Removed conflicting overflow: hidden — was fighting with overflow: visible below.
+     Keeping visible so hover card lift-effects aren't clipped. */
+  overflow: visible;
+
+  opacity: 0;
+  transform: translateY(40px);
+  transition: all 0.9s ease;
+
+  border-top: 1px solid var(--line-strong);
+}
+
+.footer-cyber.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* =========================
+   NEON CORE
+========================= */
+.neon-core {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  width: 300px;
+  height: 300px;
+
+  transform: translate(-50%, -50%);
+  background: radial-gradient(
+    circle,
+    rgba(187, 223, 77, 0.25),
+    transparent 70%
+  );
+
+  animation: pulse 3s infinite ease-in-out;
+  filter: blur(20px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: translate(-50%, -50%) scale(1);   opacity: 0.4; }
+  50%       { transform: translate(-50%, -50%) scale(1.4); opacity: 0.8; }
+}
+
+/* =========================
+   GRID BACKGROUND
+========================= */
+.footer-grid-overlay {
+  position: absolute;
+  inset: 0;
+
+  background-image:
+    linear-gradient(rgba(187, 223, 77, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(187, 223, 77, 0.08) 1px, transparent 1px);
+
+  background-size: 45px 45px;
+  animation: gridMove 12s linear infinite;
+
+  opacity: 0.35;
+  z-index: 0;
+  pointer-events: none;
+}
+
+@keyframes gridMove {
+  0%   { transform: translateY(0); }
+  100% { transform: translateY(45px); }
+}
+
+/* =========================
+   SOCIAL DOCK
+========================= */
+.social-dock {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 25px;
+  z-index: 2;
+  overflow: visible;
+}
+
+.social-dock a {
+  width: 44px;
+  height: 44px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 50%;
+  border: 1px solid var(--line-strong);
+
+  color: var(--lime);
+  background: rgba(0, 0, 0, 0.4);
+
+  transition: transform 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+  position: relative;
+  z-index: 1;
+  text-decoration: none;
+}
+
+.social-dock a:hover {
+  transform: translateY(-4px) scale(1.15);
+  box-shadow: var(--glow-lime-md);
+  color: var(--lime-bright);
+  z-index: 10;
+}
+
+/* Visible keyboard focus for accessibility */
+.social-dock a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* =========================
+   MAIN GRID
+========================= */
+.footer-main {
+  position: relative;
+  z-index: 2;
+  overflow: visible;   /* was set hidden mid-file then overridden — set once here */
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: stretch;   /* all cards fill row height so terminal aligns with siblings */
+  gap: 25px;
+}
+
+/* =========================
+   CARDS (UNIFIED)
+========================= */
+.footer-card {
+  padding: 18px;
+  border-radius: 14px;
+  position: relative;
+  z-index: 1;
+  transform: translateZ(0);
+  will-change: transform;
+
+  background: var(--surface-glass);
+  border: 1px solid var(--line);
+
+  backdrop-filter: blur(12px);
+
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.footer-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--line-strong);
+  box-shadow: var(--glow-lime-sm);
+  z-index: 10;
+}
+
+/* =========================
+   TERMINAL
+========================= */
+.terminal {
+  display: flex;
+  flex-direction: column;
+
+  /* min-height instead of a fixed height: the grid stretches all cards to the
+     tallest, and the terminal establishes a sensible floor while staying scrollable */
+  min-height: 240px;
+
+  overflow: hidden;
+  border-radius: 14px;
+  padding: 0;
+
+  background: var(--bg-term);
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  padding: 10px;
+  background: var(--bg-term-bar);
+  border-bottom: 1px solid var(--line);
+
+  flex-shrink: 0;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.red    { background: var(--dot-red); }
+.yellow { background: var(--dot-yellow); }
+.green  { background: var(--dot-green); }
+
+.terminal-title {
+  margin-left: 10px;
+  font-size: 12px;
+  opacity: 0.7;
+  font-family: var(--font-mono);
+  color: var(--lime);
+}
+
+.terminal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  scroll-behavior: smooth;
+  font-family: var(--font-mono);
+  cursor: text;
+
+  /* Removed typingGlow — it faded the entire body including the input,
+     hurting readability. Glow effect is preserved on glitch-text lines only. */
+}
+
+/* Accessible focus indication when the input (or the body itself) has focus */
+.terminal-body:focus-within,
+.terminal-body:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* Styled scrollbar */
+.terminal-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.terminal-body::-webkit-scrollbar-thumb {
+  background: var(--line-strong);
+  border-radius: 10px;
+}
+
+.terminal-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* =========================
+   TERMINAL INPUT
+========================= */
+.input-line {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+  color: var(--lime);
+}
+
+.input-line input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--lime);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  width: 100%;
+  caret-color: var(--lime);
+}
+
+.input-line input::placeholder {
+  color: rgba(187, 223, 77, 0.4);
+  font-style: italic;
+}
+
+/* iOS auto-zooms any input < 16px on focus. Bump to 16px on coarse pointers
+   (touch) only; keep the tighter 13px on fine pointers (desktop). */
+@media (pointer: coarse) {
+  .input-line input {
+    font-size: 16px;
+  }
+}
+
+/* =========================
+   TEXT EFFECTS
+========================= */
+.terminal-body p {
+  margin: 0;
+  color: var(--lime);
+}
+
+.glitch-text {
+  animation: flicker 2s infinite alternate;
+}
+
+@keyframes flicker {
+  0%   { opacity: 1; }
+  50%  { opacity: 0.85; text-shadow: 0 0 5px rgba(187, 223, 77, 0.2); }
+  100% { opacity: 1; }
+}
+
+/* =========================
+   LINKS
+========================= */
+.footer-card h4 {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.8;
+  color: var(--cyan);
+  margin: 0 0 10px;
+}
+
+.footer-card a {
+  display: block;
+  margin: 6px 0;
+  color: var(--lime);
+  text-decoration: none;
+  transition: color 0.2s ease, padding-left 0.2s ease;
+}
+
+.footer-card a:hover {
+  color: var(--lime-bright);
+  padding-left: 5px;
+}
+
+.footer-card a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--r-xs);
+}
+
+/* =========================
+   BOTTOM BAR
+========================= */
+.footer-bottom {
+  text-align: center;
+  margin-top: 25px;
+  padding-top: 15px;
+
+  border-top: 1px solid var(--line-strong);
+  font-size: 13px;
+  opacity: 0.85;
+  color: var(--text-dim);
+}
+
+/* =========================
+   REDUCED MOTION
+========================= */
+@media (prefers-reduced-motion: reduce) {
+  .footer-cyber {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .neon-core,
+  .footer-grid-overlay {
+    animation: none;
+  }
+
+  .glitch-text {
+    animation: none;
+  }
+
+  .footer-card:hover,
+  .social-dock a:hover {
+    transform: none;
+  }
+}
+
+/* =========================
+   RESPONSIVE
+========================= */
+@media (max-width: 768px) {
+  .footer-cyber {
+    padding: 50px 16px 16px;
+  }
+
+  .social-dock {
+    margin-bottom: 18px;
+  }
+
+  .footer-main {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .terminal {
+    min-height: 200px;
+  }
+
+  .footer-bottom {
+    margin-top: 18px;
+    padding-top: 14px;
+  }
+}

--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -1,123 +1,334 @@
-import React from 'react';
-const Footer = () => {
-    return (
-        <>
-        <>
-  {/* Footer */}
-  <footer className="text-center text-lg-start bg-black text-muted">
-    {/* Section: Social media */}
-    <section className="d-flex justify-content-center justify-content-lg-between p-4 border-bottom" style={{color:"#acce46"}}>
-      {/* Left */}
-      <div className="me-5 d-none d-lg-block">
-        <span>Get connected with us on social networks:</span>
-      </div>
-      {/* Left */}
-      {/* Right */}
-      <div>
-        <a href="https://www.facebook.com/electronicsclubiitk" className="me-4 link-secondary">
-          <i className="fa fa-facebook-f" />
-        </a>
-        <a href="https://youtube.com/@electronicsclub" className="me-4 link-secondary">
-          <i className="fa fa-youtube" />
-        </a>
-        <a href="https://www.instagram.com/electronicsclub.iitk/" className="me-4 link-secondary">
-          <i className="fa fa-instagram" />
-        </a>
-        <a href="https://in.linkedin.com/company/electronics-club-iit-kanpur" className="me-4 link-secondary">
-          <i className="fa fa-linkedin" />
-        </a>
-        <a href="https://github.com/electronicsclub-iitk" className="me-4 link-secondary">
-          <i className="fa fa-github" />
-        </a>
-      </div>
-      {/* Right */}
-    </section>
-    {/* Section: Social media */}
-    {/* Section: Links  */}
-    <section className="">
-      <div className="container text-center text-md-start mt-5" style={{color:"#acce46"}}>
-        {/* Grid row */}
-        <div className="row mt-3">
-          {/* Grid column */}
-          <div className="col-md-3 col-lg-4 col-xl-3 mx-auto mb-4">
-            {/* Content */}
-            <h6 className="text-uppercase fw-bold mb-4">
-              <i className="fa fa-gem me-3 text-secondary" />
-              ELECTRONICS CLUB, IIT KANPUR
-            </h6>
-            <p>
-            This is a place where students get an opportunity to think outside the academic curriculum and get practical experience by implementing and applying concepts learnt in various theoretical courses.
-            </p>
-          </div>
-          {/* Grid column */}
-          {/* Grid column */}
-          
-          {/* Grid column */}
-          {/* Grid column */}
-          <div className="col-md-3 col-lg-2 col-xl-2 mx-auto mb-4">
-            {/* Links */}
-            <h6 className="text-uppercase fw-bold mb-4">Useful links</h6>
-            <p>
-              <a href="/Projects" className="text-reset">
-                Projects
-              </a>
-            </p>
-            <p>
-              <a href="/Database" className="text-reset">
-                Database
-              </a>
-            </p>
-            <p>
-              <a href="/Team" className="text-reset">
-                Team
-              </a>
-            </p>
-            <p>
-              <a href="/Comp" className="text-reset">
-                Get Components
-              </a>
-            </p>
-          </div>
-          {/* Grid column */}
-          {/* Grid column */}
-          <div className="col-md-4 col-lg-3 col-xl-3 mx-auto mb-md-0 mb-4">
-            {/* Links */}
-            <h6 className="text-uppercase fw-bold mb-4">Contact Us</h6>
-            <p>
-            < a className="text-reset" href='https://maps.app.goo.gl/7KecUz57uZVgfD1R8'><i className="fa fa-map-marker me-3 text-secondary" /> Hall 3, IIT KANPUR</a>
-            </p>
-            <p>
-            < a className="text-reset" href='mailto:eclub.iitk@gmail.com'><i className="fa fa-envelope me-3 text-secondary" />
-              eclub.iitk@gmail.com</a>
-            </p>
-            <p>
-            < a className="text-reset"href='https://www.instagram.com/electronicsclub.iitk/'><i className="fa fa-instagram me-3 text-secondary" />
-              electronicsclub.iitk</a>
-            </p>
-        
-          </div>
-          {/* Grid column */}
-        </div>
-        {/* Grid row */}
-      </div>
-    </section>
-    {/* Section: Links  */}
-    {/* Copyright */}
-    <div
-      className="text-center p-4"
-      style={{ backgroundColor: "rgb(172, 206, 70)", color:"black" }}
-    >
-      © 2025 Copyright:
-      &nbsp;&nbsp;&nbsp;<a className="text-reset" href="/">
-          EClub IIT KANPUR
-      </a>
-    </div>
-    {/* Copyright */}
-  </footer>
-  {/* Footer */}
-</>
+import React, { useEffect, useState, useRef } from "react";
+import { Link } from "react-router-dom";
+import "./Footer.css";
 
-        </>
-    );
+const bootSets = [
+  [
+    "initializing electronics core...",
+    "loading circuit database...",
+    "compiling project modules...",
+    "optimizing signal flow...",
+    "status: READY"
+  ],
+  [
+    "booting EClub kernel...",
+    "detecting hardware interfaces...",
+    "mapping PCB layers...",
+    "synchronizing nodes...",
+    "status: ONLINE"
+  ],
+  [
+    "starting innovation engine...",
+    "loading FPGA logic...",
+    "initializing sensors...",
+    "calibrating systems...",
+    "status: ACTIVE"
+  ]
+];
+
+const systemBrain = {
+  help: "Available commands: help, status, projects, stats, clear",
+  status: "All systems operational ✔ Neural link stable",
+  projects: "Fetching Electronics Club project database...",
+  stats: "CPU: 34% | RAM: 61% | Nodes: 12 online | Signal: stable",
 };
+
+// media query helper — SSR-safe, returns false when matchMedia is unavailable
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const Footer = () => {
+  const footerRef = useRef(null);
+  const terminalRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const [visible, setVisible] = useState(false);
+
+  const [bootIndex] = useState(() =>
+    Math.floor(Math.random() * bootSets.length)
+  );
+
+  const lines = bootSets[bootIndex];
+
+  const [output, setOutput] = useState([]);
+  const [lineIndex, setLineIndex] = useState(0);
+  const [charIndex, setCharIndex] = useState(0);
+
+  const [cmd, setCmd] = useState("");
+  const [cmdOutput, setCmdOutput] = useState([]);
+
+  const [history, setHistory] = useState([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
+  // scroll reveal
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) setVisible(true);
+      },
+      { threshold: 0.2 }
+    );
+
+    if (footerRef.current) observer.observe(footerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  // auto scroll terminal — single unified effect using ref
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    }
+  }, [output, cmdOutput]);
+
+  // typing engine — gated by reduced-motion.
+  // If the user prefers reduced motion, skip the char-by-char animation
+  // and render the completed boot lines immediately (the CSS reduced-motion
+  // block can't stop a JS timer, so we short-circuit it here).
+  useEffect(() => {
+    if (!visible) return;
+
+    if (prefersReducedMotion()) {
+      // show all boot lines at once, mark typing complete
+      setOutput(lines.slice());
+      setLineIndex(lines.length);
+      setCharIndex(0);
+      return;
+    }
+
+    if (lineIndex >= lines.length) return;
+
+    const line = lines[lineIndex];
+
+    const timer = setTimeout(() => {
+      setOutput((prev) => {
+        const copy = [...prev];
+        if (!copy[lineIndex]) copy[lineIndex] = "";
+        copy[lineIndex] += line[charIndex];
+        return copy;
+      });
+
+      setCharIndex((prev) => {
+        const next = prev + 1;
+        if (next === line.length) {
+          setLineIndex((l) => l + 1);
+          return 0;
+        }
+        return next;
+      });
+    }, 28);
+
+    return () => clearTimeout(timer);
+  }, [visible, lineIndex, charIndex, lines]);
+
+  // command engine
+  const handleCommand = (e) => {
+    if (e.key !== "Enter") return;
+
+    const trimmed = cmd.trim();
+    if (!trimmed) return;
+
+    const input = trimmed.toLowerCase();
+
+    // save to history and reset index
+    setHistory((prev) => [...prev, trimmed]);
+    setHistoryIndex(-1);
+
+    // handle clear separately
+    if (input === "clear") {
+      setCmdOutput([]);
+      setCmd("");
+      return;
+    }
+
+    const response = systemBrain[input];
+
+    if (response) {
+      // store command echo and response as plain strings — JSX adds no extra ">"
+      setCmdOutput((prev) => [...prev, `> ${trimmed}`, response]);
+      setCmd("");
+      return;
+    }
+
+    setCmdOutput((prev) => [...prev, `> ${trimmed}`, "AI processing request..."]);
+    setCmd("");
+
+    setTimeout(() => {
+      setCmdOutput((prev) => [
+        ...prev,
+        `AI: command "${input}" not found. Try 'help'.`
+      ]);
+    }, 400);
+  };
+
+  // history navigation (↑ ↓)
+  const handleKeyNav = (e) => {
+    if (history.length === 0) return;
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      // clamp to 0 so we never go below the oldest entry
+      const idx = historyIndex < 0
+        ? history.length - 1
+        : Math.max(0, historyIndex - 1);
+      setHistoryIndex(idx);
+      setCmd(history[idx]);
+    }
+
+    if (e.key === "ArrowDown") {
+      if (historyIndex < 0) return;
+
+      if (historyIndex >= history.length - 1) {
+        setHistoryIndex(-1);
+        setCmd("");
+        return;
+      }
+
+      const idx = historyIndex + 1;
+      setHistoryIndex(idx);
+      setCmd(history[idx]);
+    }
+  };
+
+  // clicking anywhere in the terminal body focuses the command input
+  const focusInput = () => {
+    if (inputRef.current) inputRef.current.focus();
+  };
+
+  const socialLinks = [
+    {
+      icon: "fa-facebook-f",
+      href: "https://www.facebook.com/electronicsclubiitk",
+      label: "Facebook"
+    },
+    {
+      icon: "fa-instagram",
+      href: "https://www.instagram.com/electronicsclub.iitk/",
+      label: "Instagram"
+    },
+    {
+      icon: "fa-linkedin",
+      href: "https://www.linkedin.com/company/electronics-club-iit-kanpur/",
+      label: "LinkedIn"
+    },
+    {
+      icon: "fa-github",
+      href: "https://github.com/ElectronicsClub-IITK",
+      label: "GitHub"
+    },
+  ];
+
+  return (
+    <footer ref={footerRef} className={`footer-cyber ${visible ? "show" : ""}`}>
+
+      <div className="footer-grid-overlay" />
+      <div className="neon-core" />
+
+      {/* SOCIAL */}
+      <div className="social-dock">
+        {socialLinks.map(({ icon, href, label }) => (
+          <a
+            key={label}
+            href={href}
+            aria-label={label}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <i className={`fa ${icon}`} aria-hidden="true" />
+          </a>
+        ))}
+      </div>
+
+      {/* TERMINAL + LINKS + CONTACT */}
+      <section className="footer-main">
+
+        <div className="footer-card terminal">
+
+          <div className="terminal-header">
+            <span className="dot red" />
+            <span className="dot yellow" />
+            <span className="dot green" />
+            <span className="terminal-title">eclub@iitk:~$</span>
+          </div>
+
+          <div
+            className="terminal-body"
+            ref={terminalRef}
+            onClick={focusInput}
+            role="log"
+            aria-live="polite"
+          >
+
+            <div aria-hidden="true">
+              {output.map((line, i) => (
+                <p key={`boot-${i}`} className="glitch-text">&gt; {line}</p>
+              ))}
+            </div>
+
+            {/* cmdOutput lines already carry their own ">" prefix for commands;
+                response lines are plain text — render without adding another ">" */}
+            {cmdOutput.map((line, i) => (
+              <p key={`cmd-${i}`}>{line}</p>
+            ))}
+
+            <div className="input-line">
+              <span>&gt;&nbsp;</span>
+              <input
+                ref={inputRef}
+                value={cmd}
+                aria-label="Terminal command input"
+                onChange={(e) => setCmd(e.target.value)}
+                onKeyDown={(e) => {
+                  handleCommand(e);
+                  handleKeyNav(e);
+                }}
+                placeholder="type 'help'"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+
+          </div>
+        </div>
+
+        {/* LINKS */}
+        <div className="footer-card">
+          <h4>Explore</h4>
+          <Link to="/Projects">Projects</Link>
+          <Link to="/Database">Database</Link>
+          <Link to="/Team">Team</Link>
+          <Link to="/Comp">Components</Link>
+        </div>
+
+        {/* CONTACT */}
+        <div className="footer-card">
+          <h4>Contact</h4>
+          <a
+            href="https://maps.google.com/?q=Hall+3+IIT+Kanpur"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Hall 3, IIT Kanpur
+          </a>
+          <a href="mailto:eclub.iitk@gmail.com">eclub.iitk@gmail.com</a>
+          <a
+            href="https://www.instagram.com/electronicsclub.iitk/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Instagram
+          </a>
+        </div>
+
+      </section>
+
+      <div className="footer-bottom">
+        © {new Date().getFullYear()} Electronics Club, IIT Kanpur
+      </div>
+
+    </footer>
+  );
+};
+
 export default Footer;

--- a/src/Components/Navbar.css
+++ b/src/Components/Navbar.css
@@ -1,257 +1,354 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu&display=swap');
-*{
-    margin: 0px;
-    padding: 0px;
-    box-sizing: border-box;
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+/* ---- site-wide resets / tokens (kept for the rest of the app) ---- */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 :root {
-	--primary: rgba(37, 37, 37, 1.0);
-	--secondary:  #BBDF4D;
-	--shades: rgba(238, 238, 238, 1.0);
+  --primary: rgba(37, 37, 37, 1.0);
+  --secondary: #BBDF4D;
+  --shades: rgba(238, 238, 238, 1.0);
 }
-
 * {
-	scroll-behavior: smooth;
+  scroll-behavior: smooth;
 }
-
 body {
-	font-family: 'Ubuntu', sans-serif;
-	line-height: 1.6;
-	margin: 0;
-}
-.heading_name{
-	align-self: center;
-	margin-bottom:0px;
+  font-family: 'Ubuntu', sans-serif;
+  line-height: 1.6;
+  margin: 0;
 }
 
-.header {
-    height: auto; /* Allow the header to be only as tall as the navbar content */
-    min-height: fit-content;
+/* ==================================================================
+   CYBER NAVBAR (.nvx) — NEURAL_BUILD // OS
+   Colors, spacing, motion pull from the global tokens in src/index.css.
+   ================================================================== */
+.nvx {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+  height: var(--nav-h);
+  padding: 0 var(--space-5);
+
+  font-family: var(--font-mono);
+  background: var(--surface-nav);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--line);
+  overflow: hidden; /* keep .nvx__scan from painting outside the bar */
+  transition:
+    background var(--dur-4) var(--ease-out),
+    border-color var(--dur-4) var(--ease-out),
+    box-shadow var(--dur-4) var(--ease-out);
+}
+.nvx--scrolled {
+  background: var(--surface-nav-scrolled);
+  border-bottom-color: var(--line-strong);
+  box-shadow: var(--shadow-nav);
 }
 
-.header,
-.home,
-.about,
-.portfolio,
-.contact,
-.footer {
-	position: relative;
+/* On the snap home page the navbar floats (fixed) so it doesn't push the hero
+   down — the hero fills the whole first screen; the bar is see-through until you
+   scroll, then it solidifies via .nvx--scrolled. */
+html.home-snap .nvx {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+html.home-snap .nvx:not(.nvx--scrolled) {
+  background: linear-gradient(180deg, rgba(5, 7, 10, 0.6), transparent);
+  border-bottom-color: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
-.header h1,
-.home h1,
-.about h1,
-.portfolio h1,
-.contact h1,
-.footer h1 {
-	margin: 0;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
+/* animated bottom scan line */
+.nvx__scan {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 1px;
+  width: 40%;
+  background: linear-gradient(90deg, transparent, var(--lime), transparent);
+  animation: nvx-scan 5s linear infinite;
+  opacity: 0.7;
+  pointer-events: none;
+}
+@keyframes nvx-scan {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(250%); }
 }
 
-#active{
-    color:#BBDF4D;
+/* ---------- brand ---------- */
+.nvx__brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  text-decoration: none;
+  flex-shrink: 0;
+}
+.nvx__logo {
+  filter: drop-shadow(0 0 6px rgba(187, 223, 77, 0.35));
+}
+.nvx__word {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  font-size: 1.02rem;
+  color: var(--text-strong);
+  white-space: nowrap;
+}
+.nvx__word b {
+  color: var(--lime);
+  font-weight: 700;
+  margin-left: 0.42em; /* real gap between ELECTRONICS and CLUB */
 }
 
-.header h1,
-.footer h1 {
-	color: var(--shades);
+/* ---------- desktop links ---------- */
+.nvx__links {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  list-style: none;
+  height: 100%;
+}
+.nvx__links > li {
+  display: flex;
+  height: 100%;
+}
+.nvx__link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition: color var(--t-hover);
+}
+.nvx__link::after {
+  content: "";
+  position: absolute;
+  left: var(--space-3);
+  right: var(--space-3);
+  bottom: 8px;
+  height: 1px;
+  background: var(--lime);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--dur-3) var(--ease-out);
+}
+.nvx__link:hover {
+  color: var(--text-strong);
+}
+.nvx__link:hover::after {
+  transform: scaleX(1);
+}
+.nvx__link.is-active {
+  color: var(--lime);
+  text-shadow: var(--text-glow-lime);
+}
+.nvx__link.is-active::after {
+  transform: scaleX(1);
+  box-shadow: 0 0 8px var(--lime);
 }
 
-.footer {
-	height: 50vh;
-	background-color: var(--primary);
+/* ---------- hamburger (hidden on desktop) ---------- */
+.nvx__burger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 44px;
+  height: 44px;
+  padding: 0 9px;
+  background: transparent;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  z-index: 1002;
+}
+.nvx__burger span {
+  height: 2px;
+  width: 100%;
+  background: var(--lime);
+  transition: transform var(--dur-3) var(--ease-out), opacity var(--dur-2) var(--ease-out);
+}
+.nvx__burger.is-open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.nvx__burger.is-open span:nth-child(2) { opacity: 0; }
+.nvx__burger.is-open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* ---------- fullscreen overlay menu ---------- */
+.nvx__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 0 var(--space-7);
+  gap: 0;
+  background: var(--surface-overlay);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  opacity: 0;
+  visibility: hidden;
+  clip-path: inset(0 0 100% 0);
+  transition:
+    clip-path var(--dur-5) var(--ease-out),
+    opacity var(--dur-4) var(--ease-out),
+    visibility var(--dur-4);
+}
+.nvx__overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+  clip-path: inset(0 0 0% 0);
+}
+.nvx__overlay-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(187, 223, 77, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(187, 223, 77, 0.06) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(circle at 30% 40%, black, transparent 75%);
+  -webkit-mask-image: radial-gradient(circle at 30% 40%, black, transparent 75%);
+  pointer-events: none;
+}
+.nvx__overlay ul {
+  list-style: none;
+  position: relative;
+  z-index: 2;
+  padding: var(--space-9) 0;
+}
+.nvx__overlay li {
+  opacity: 0;
+  transform: translateX(-24px);
+  transition:
+    opacity var(--dur-4) var(--ease-out),
+    transform var(--dur-4) var(--ease-out);
+}
+.nvx__overlay.is-open li {
+  opacity: 1;
+  transform: translateX(0);
+}
+.nvx__overlay a {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  padding: 10px 0;
+  min-height: 44px;
+  text-decoration: none;
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: clamp(1.8rem, 8vw, 3rem);
+  letter-spacing: 0.01em;
+  transition: color var(--t-hover), padding-left var(--dur-3) var(--ease-out);
+}
+.nvx__overlay a:hover,
+.nvx__overlay a.is-active {
+  color: var(--lime);
+  padding-left: 12px;
+  text-shadow: 0 0 20px rgba(187, 223, 77, 0.4);
+}
+.nvx__idx {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--cyan);
+  font-style: normal;
+  opacity: 0.8;
+}
+.nvx__overlay-foot {
+  position: absolute;
+  bottom: 30px;
+  left: var(--space-7);
+  right: var(--space-7);
+  z-index: 2;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  color: rgba(187, 223, 77, 0.5);
 }
 
-.header {
-	background-color: var(--primary);
+/* ---------- focus-visible (keyboard) ---------- */
+.nvx__brand:focus-visible,
+.nvx__link:focus-visible,
+.nvx__burger:focus-visible,
+.nvx__overlay a:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--r-xs);
 }
 
-.navbar {
-	padding-top: .5em;
-	padding-bottom: .5em;
-	background-color: #000000;
-	-webkit-box-shadow: 0 14px 14px -14px rgba(0, 0, 0, .75);
-	-moz-box-shadow: 0 14px 14px -14px rgba(0, 0, 0, .75);
-	box-shadow: 0 14px 14px -14px rgba(0, 0, 0, .75);
-}
-
-.sticky {
-	position: -webkit-sticky;
-	position: sticky;
-	top: 0;
-	z-index: 1;
-}
-
-.hidden {
-	display: none;
-}
-
-.display__logo {
-	font-size: 2.5rem;
-	margin-bottom: .5rem;
-	font-family: inherit;
-	font-weight: 500;
-	line-height: 1.2;
-	color: inherit;
-}
-
-.nav__items {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-}
-
-.nav__link {
-	color: var(--shades);
-	text-decoration: none;
-}
-
-.brand {
-	margin: 0;
-	font-size: 1.45em;
-}
-
-.brand a {
-	padding: 10px 15px;
-	text-align: center;
-	display: block;
-}
-
-.logo {
-	display: inline-block;
-	padding-top: .3125rem;
-	padding-bottom: .3125rem;
-	margin-right: 1rem;
-	line-height: inherit;
-}
-.logo{display: flex;}
-
-
-
-.nav__items {
-	margin-top: 5px;
-
-}
-
-.brand .nav__link,
-.nav__items .nav__link {
-	padding: 10px 15px;
-	text-align: center;
-	display: block;
-}
-
-.nav__items .nav__link {
-	color: var(--shades);
-	font-size: 0.99rem;
-}
-
-.nav__items .nav__link:hover {
-	color: var(--secondary);
-}
-
-
-
-
-@media (min-width: 904px) {
-
-	.navbar,
-	.nav__items {
-		display: flex;
-	}
-
-	.navbar {
-		flex-direction: column;
-		align-items: center;
-	}
-
-	.navbar {
-		flex-direction: row;
-		justify-content: space-between;
-	}
-}
-
-@media (min-width: 904px) {
-    .navbar {
-        display: flex;
-        flex-direction: column; /* Stacks the brand over the links */
-        align-items: center;    /* Centers everything horizontally */
-        padding-top: 5px;       /* Tightens the bar to the very top */
-        padding-bottom: 5px;
-        gap: 2px;              /* Precise control over the space between line 1 and 2 */
-    }
-
-    .brand {
-        margin: 0;              /* Removes any outer spacing from the brand container */
-    }
-
-    .brand .nav__link {
-        padding: 2px 0;         /* Shrinks the clickable area around the logo/text */
-    }
-
-    .heading_name {
-        margin: 0;              /* Removes default <p> margins that cause gaps */
-        line-height: 1;         /* Keeps the text height as small as the font allows */
-    }
-
-    .nav__items {
-        display: flex;
-        justify-content: center; /* Centers the list of links */
-        flex-wrap: wrap;        /* Allows items to wrap nicely if screen shrinks */
-        margin: 0;              /* Explicitly removes the 5px margin from your original code */
-        padding: 0;
-    }
-
-    .nav__link {
-        padding: 4px 12px;      /* Reduced vertical padding to keep lines close */
-    }
-}
-
-#nav:checked+.nav__open {
-	transform: rotate(45deg);
-}
-
-#nav:checked+.nav__open i {
-	background-color: var(--shades);
-	transition: transform 0.2s ease;
-}
-
-#nav:checked+.nav__open i:nth-child(1) {
-	transform: translateY(6px) rotate(180deg);
-}
-
-#nav:checked+.nav__open i:nth-child(2) {
-	opacity: 0;
-}
-
-#nav:checked~.nav__item a {
-	display: block !important;
-}
-
-#nav:checked+.nav__open i:nth-child(3) {
-	transform: translateY(-6px) rotate(90deg);
-}
-
-#nav:checked~.nav {
-    z-index: 9990;
-    opacity: 1;
-    visibility: visible; /* Add this line to make the navbar visible when the checkbox is checked */
+/* ---------- responsive switch ----------
+   The 9 links crowd between ~1025-1200px, so swap to the burger at 1100px. */
+@media (min-width: 1101px) and (max-width: 1240px) {
+  .nvx__link {
+    padding: 0 var(--space-2);
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
   }
-
-#nav:checked~.nav ul li a {
-	opacity: 1;
-	transform: translateY(0);
 }
-.brand, .logo {
-    overflow: hidden; /* This is the "kill switch" for that scrollbar */
-    display: flex;
-    align-items: center;
+@media (max-width: 1100px) {
+  .nvx__links { display: none; }
+  .nvx__burger { display: flex; }
+}
+@media (min-width: 1101px) {
+  .nvx__overlay { display: none; }
 }
 
-.heading_name {
-    margin: 0;
-    line-height: 1.2; /* Ensure the line height isn't taller than the container */
-    white-space: nowrap; /* Prevents the text from trying to wrap/stack */
+/* ---------- landscape / short viewports ---------- */
+@media (max-height: 600px) {
+  .nvx__overlay {
+    justify-content: flex-start;
+    padding-top: 70px;
+  }
+  .nvx__overlay ul {
+    padding: 0 0 var(--space-8);
+  }
+  .nvx__overlay a {
+    font-size: 1.3rem;
+    padding: 6px 0;
+    min-height: 0;
+  }
+  .nvx__overlay-foot {
+    position: static;
+    margin-top: var(--space-4);
+  }
+}
+
+/* ---------- reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .nvx,
+  .nvx__link,
+  .nvx__link::after,
+  .nvx__burger span,
+  .nvx__overlay a {
+    transition: none;
+  }
+  .nvx__scan { animation: none; }
+  .nvx__overlay {
+    transition: opacity var(--dur-2) var(--ease-out), visibility var(--dur-2);
+  }
+  .nvx__overlay li {
+    transition: opacity var(--dur-2) var(--ease-out);
+    transform: none;
+  }
+  .nvx__overlay.is-open li { transform: none; }
 }

--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -1,79 +1,199 @@
-import React from "react";
-import { Link, useNavigate } from "react-router-dom";
-import './Navbar.css';
+import React, { useState, useEffect, useRef } from "react";
+import { Link, useLocation } from "react-router-dom";
+import "./Navbar.css";
+
+const LINKS = [
+  { to: "/", label: "Home" },
+  { to: "/Projects", label: "Projects" },
+  { to: "/Database", label: "Database" },
+  { to: "/Articles", label: "Articles" },
+  { to: "/Team", label: "Team" },
+  { to: "/Comp", label: "Components" },
+  { to: "/Challenge", label: "Challenge" },
+  { to: "/Leaderboard", label: "Leaderboard" },
+  { to: "/Gallery", label: "Gallery" },
+];
+
+/* EClub mark — the dark-theme variant (lime E + white C) with a
+   transparent background; /logo.png is the IITK seal, kept for other uses */
+const LOGO = `${process.env.PUBLIC_URL || ""}/eclub.png`;
+
+// first path segment of a route ("/Projects" -> "projects", "/" -> "")
+const segOf = (path) => path.toLowerCase().split("/")[1] || "";
 
 const Navbar = () => {
-  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
 
-  const isActive = (path) => {
-    return window.location.pathname === path;
-  };
+  const burgerRef = useRef(null);
+  const firstOverlayLinkRef = useRef(null);
+  const overlayRef = useRef(null);
+  const scrollYRef = useRef(0);
+
+  // close the mobile menu whenever the route changes
+  useEffect(() => setOpen(false), [pathname]);
+
+  // solidify the bar once the user scrolls off the hero
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // lock page scroll while the fullscreen menu is open (position:fixed technique
+  // so the scroll position is preserved and the body can't scroll behind it)
+  useEffect(() => {
+    const { body } = document;
+    if (open) {
+      scrollYRef.current = window.scrollY;
+      body.style.position = "fixed";
+      body.style.top = `-${scrollYRef.current}px`;
+      body.style.left = "0";
+      body.style.right = "0";
+      body.style.width = "100%";
+      body.style.overflow = "hidden";
+      body.style.overscrollBehavior = "contain";
+      return () => {
+        body.style.position = "";
+        body.style.top = "";
+        body.style.left = "";
+        body.style.right = "";
+        body.style.width = "";
+        body.style.overflow = "";
+        body.style.overscrollBehavior = "";
+        window.scrollTo(0, scrollYRef.current);
+      };
+    }
+    return undefined;
+  }, [open]);
+
+  // Escape-to-close for the overlay
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // focus trap: keep Tab / Shift+Tab cycling within the overlay's links so
+  // focus can't slip into the visually-covered page behind it
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => {
+      if (e.key !== "Tab") return;
+      const overlay = overlayRef.current;
+      if (!overlay) return;
+      const focusables = overlay.querySelectorAll("a[href]");
+      if (!focusables.length) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // move focus into the overlay on open, return it to the burger on close
+  const prevOpen = useRef(open);
+  useEffect(() => {
+    if (open && !prevOpen.current) {
+      firstOverlayLinkRef.current?.focus();
+    } else if (!open && prevOpen.current) {
+      burgerRef.current?.focus();
+    }
+    prevOpen.current = open;
+  }, [open]);
+
+  // '/' active only on exact root; everything else by first path segment
+  const isActive = (to) => segOf(pathname) === segOf(to);
 
   return (
     <>
-      <nav className="sticky navbar">
-    <div className="brand  display__logo">
-      <a href="#top" className="nav__link">
-        
-        <span className="logo"><img src="logo.png" height={58} width={58}/> <p className="heading_name"> &nbsp; ELECTRONICS CLUB</p></span>
-      </a>
-    </div>
-    <input type="checkbox" id="nav" className="hidden" />
-    <label htmlFor="nav" className="nav__open">
-      <i />
-      <i />
-      <i />
-    </label>
-    <div className="nav">
-          <ul className="nav__items">
-            <li className="nav__item">
-              <Link to="/" id={isActive("/") ? "active" : ""} className="nav__link">
-                Home
+      <nav className={`nvx ${scrolled ? "nvx--scrolled" : ""} ${open ? "nvx--open" : ""}`}>
+        <span className="nvx__scan" aria-hidden="true" />
+
+        <Link
+          to="/"
+          className="nvx__brand"
+          aria-label="Electronics Club — Home"
+          tabIndex={open ? -1 : undefined}
+        >
+          <img src={LOGO} alt="" className="nvx__logo" width={38} height={38} />
+          <span className="nvx__word">
+            ELECTRONICS<b>CLUB</b>
+          </span>
+        </Link>
+
+        <ul className="nvx__links">
+          {LINKS.map((l) => (
+            <li key={l.to}>
+              <Link
+                to={l.to}
+                className={`nvx__link ${isActive(l.to) ? "is-active" : ""}`}
+                aria-current={isActive(l.to) ? "page" : undefined}
+                tabIndex={open ? -1 : undefined}
+              >
+                {l.label}
               </Link>
             </li>
-            <li className="nav__item">
-              <Link to="/Projects" id={isActive("/Projects") ? "active" : ""} className="nav__link">
-                Projects
-              </Link>
-            </li>
-            <li className="nav__item">
-              <Link to="/Database" id={isActive("/Database") ? "active" : ""} className="nav__link">
-                Database
-              </Link>
-            </li>
-            <li className="nav__item">
-              <Link to="/Articles" id={isActive("/Articles") ? "active" : ""} className="nav__link">
-                Articles
-              </Link>
-            </li>
-            <li className="nav__item">
-              <Link to="/Team" id={isActive("/Team") ? "active" : ""} className="nav__link">
-                Team
-              </Link>
-            </li>
-            <li className="nav__item">
-              <Link to="/Comp" id={isActive("/Comp") ? "active" : ""} className="nav__link">
-                Get Components
-              </Link>
-            </li>
-            <li className="nav__item">
-               <Link to="/Challenge" id={isActive("/Challenge") ? "active" : ""} className="nav__link">
-                 Monthly Challenge
-                 </Link>
-            </li>
-            <li className="nav__item">
-                 <Link to="/Leaderboard" id={isActive("/Leaderboard") ? "active" : ""} className="nav__link">
-                   Leaderboard
-                   </Link>
-             </li>
-            <li className="nav__item">
-                 <Link to="/Gallery" id={isActive("/Gallery") ? "active" : ""} className="nav__link">
-                   Gallery
-                   </Link>
-             </li>
-          </ul>
-        </div>
+          ))}
+        </ul>
+
+        <button
+          ref={burgerRef}
+          className={`nvx__burger ${open ? "is-open" : ""}`}
+          onClick={() => setOpen((o) => !o)}
+          aria-label={open ? "Close menu" : "Open menu"}
+          aria-expanded={open}
+          aria-controls="nvx-overlay"
+        >
+          <span />
+          <span />
+          <span />
+        </button>
       </nav>
+
+      {/* fullscreen mobile menu */}
+      <div
+        id="nvx-overlay"
+        ref={overlayRef}
+        className={`nvx__overlay ${open ? "is-open" : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-hidden={!open}
+      >
+        <div className="nvx__overlay-grid" aria-hidden="true" />
+        <ul>
+          {LINKS.map((l, i) => (
+            <li key={l.to} style={{ transitionDelay: `${0.06 + i * 0.04}s` }}>
+              <Link
+                ref={i === 0 ? firstOverlayLinkRef : undefined}
+                to={l.to}
+                className={isActive(l.to) ? "is-active" : ""}
+                aria-current={isActive(l.to) ? "page" : undefined}
+                onClick={() => setOpen(false)}
+                tabIndex={open ? undefined : -1}
+              >
+                <em className="nvx__idx">{String(i + 1).padStart(2, "0")}</em>
+                <span>{l.label}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <p className="nvx__overlay-foot">EST · IIT KANPUR · INNOVATION IMAGINATION APPLICATION</p>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## What this does
- **Navbar** — restyled to the cyber language (sticky, mono nav items, lime active states). The logo is now the **EClub mark** (`/eclub.png` — the transparent-background variant with a white C + lime E, made for dark surfaces). The IITK seal stays untouched at `/logo.png` for anything else that needs it.
- **Footer** — rebuilt in the same language; its styles move out into a new `Footer.css`.

## Review notes
- Both eclub.png and logo192.png carry real alpha channels (verified at the PNG palette level); eclub.png is specifically the dark-theme variant — the logo192 twin has a near-black C that would vanish on the navbar.
- Nav routes match the router table added in PR 01.

---
**Series notes** (part of a 14-PR redesign, preview: https://eclub-beta.netlify.app): every PR touches a disjoint set of files, so they merge conflict-free in any order (recommended: 01 → 14). The site builds only once the whole series is in. Nothing deploys to the live site until `npm run deploy` is run after the series lands.