### PR TITLE
Gallery page: camera-viewfinder hero and dense media grid from Drive

### DIFF
--- a/src/Components/Gallery.css
+++ b/src/Components/Gallery.css
@@ -1,144 +1,522 @@
-/* --- Base Container --- */
-.gallery-container {
+/* ==================================================================
+   GALLERY — Electronics Club, IIT Kanpur
+   Same cyber/HUD language as the homepage: CircuitBG constellation,
+   transmission-static hero, scanlines, vignette, RGB-split glitch
+   title, dense "tetris" media grid with HUD hover reticles.
+   Uses the global design tokens defined in src/index.css.
+   ================================================================== */
+
+.gal-root {
   position: relative;
+  background: var(--bg-0);
+  color: var(--text);
+  font-family: var(--font-sans);
+  overflow-x: clip;
+}
+
+.gal-root *,
+.gal-root *::before,
+.gal-root *::after {
+  box-sizing: border-box;
+}
+
+/* ============================ HERO ============================ */
+.gal-hero {
+  position: relative;
+  z-index: 1;
+  min-height: 56vh;
   width: 100%;
-  min-height: 100vh;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  padding-top: 80px;
-  padding-bottom: 50px;
-}
-
-.gallery-bg {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image: url('/public/Eclub_bg.webp');
-  background-size: cover;
-  background-position: center;
-  opacity: 0.6;
-  z-index: -1;
-}
-
-.gallery-content {
+  overflow: hidden;
   text-align: center;
-  color: rgb(191, 255, 0);
-  max-width: 1200px; /* Constrain width to keep the rectangle neat */
-  width: 95%;
+  padding: 90px 20px 70px;
+  border-bottom: 1px solid var(--line);
+  background:
+    radial-gradient(120% 80% at 50% 0%, rgba(187, 223, 77, 0.08), transparent 60%),
+    radial-gradient(80% 60% at 50% 100%, rgba(61, 242, 255, 0.08), transparent 60%),
+    var(--bg-0);
 }
 
-.gallery-title {
-  font-size: 4rem;
-  margin-bottom: 50px;
-  border-bottom: 3px solid #BBDF4D;
-  padding-bottom: 15px;
+/* moving perspective grid, same rhythm as the Articles/Components heroes */
+.gal-grid-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 46px 46px;
+  mask-image: radial-gradient(circle at 50% 50%, black 10%, transparent 78%);
+  -webkit-mask-image: radial-gradient(circle at 50% 50%, black 10%, transparent 78%);
+  animation: gal-grid-move 12s linear infinite;
+  pointer-events: none;
+}
+@keyframes gal-grid-move {
+  to { background-position: 46px 46px; }
+}
+
+/* one-shot camera flash when the page opens */
+.gal-flash {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: radial-gradient(70% 70% at 50% 45%, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.5) 55%, transparent 80%);
+  opacity: 0;
+  pointer-events: none;
+  animation: gal-flash-pop 0.85s ease-out 0.15s;
+}
+@keyframes gal-flash-pop {
+  0% { opacity: 0; }
+  12% { opacity: 0.9; }
+  100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gal-flash { animation: none; }
+}
+
+.gal-scanlines {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0px,
+    rgba(0, 0, 0, 0) 2px,
+    rgba(0, 0, 0, 0.22) 3px,
+    rgba(0, 0, 0, 0) 4px
+  );
+  mix-blend-mode: overlay;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.gal-vignette {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  box-shadow: var(--vignette-inset);
+}
+
+/* HUD corner labels */
+.gal-hud {
+  position: absolute;
+  z-index: 3;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: rgba(187, 223, 77, 0.65);
+  pointer-events: none;
+}
+.gal-hud-tr { top: 18px; right: 20px; }
+
+/* REC indicator — blinking tally light + running timecode */
+.gal-hud-rec {
+  top: 18px;
+  left: 20px;
+  color: #ff6b6b;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.gal-rec-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #ff4d4d;
+  box-shadow: 0 0 10px rgba(255, 77, 77, 0.8);
+  animation: gal-rec-blink 1.2s steps(2) infinite;
+}
+@keyframes gal-rec-blink {
+  50% { opacity: 0.15; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gal-rec-dot { animation: none; }
+}
+
+.gal-hero-content {
+  position: relative;
+  z-index: 4;
+  max-width: 720px;
+}
+
+.gal-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.5em;
+  color: var(--cyan);
+  margin: 0 0 18px;
+  opacity: 0.9;
+}
+
+/* ---- viewfinder: focus brackets + pull-focus title ---- */
+.gal-viewfinder {
+  position: relative;
   display: inline-block;
-  color: #BBDF4D;
-  text-shadow: 0 0 15px rgba(187, 223, 77, 0.5);
+  padding: clamp(18px, 3vw, 34px) clamp(26px, 4vw, 48px);
+  animation: gal-breathe 4.5s ease-in-out 1.6s infinite;
+}
+@keyframes gal-breathe {
+  50% { transform: scale(1.012); }
 }
 
-.error-message {
-  color: #ff4d4d;
-  font-size: 1.2rem;
+/* the title pulls focus: blurred → sharp, like a lens locking on */
+.gal-title {
+  font-size: clamp(2.4rem, 8vw, 5.5rem);
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: 0.02em;
+  margin: 0;
+  color: #fff;
+  position: relative;
+  text-shadow: 0 0 40px rgba(187, 223, 77, 0.35);
+  animation: gal-pull-focus 1.1s var(--ease-out) 0.2s both;
 }
+@keyframes gal-pull-focus {
+  0% {
+    filter: blur(12px);
+    opacity: 0;
+    letter-spacing: 0.14em;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    filter: blur(0);
+    opacity: 1;
+    letter-spacing: 0.02em;
+  }
+}
+
+/* corner brackets fly in from outside and lock on */
+.gal-vf {
+  position: absolute;
+  width: clamp(18px, 2.6vw, 30px);
+  height: clamp(18px, 2.6vw, 30px);
+  animation: gal-vf-lock 0.7s var(--ease-out) 0.45s both;
+}
+.gal-vf-tl { top: 0; left: 0; border-top: 2px solid var(--lime); border-left: 2px solid var(--lime); --dx: -1; --dy: -1; }
+.gal-vf-tr { top: 0; right: 0; border-top: 2px solid var(--lime); border-right: 2px solid var(--lime); --dx: 1; --dy: -1; }
+.gal-vf-bl { bottom: 0; left: 0; border-bottom: 2px solid var(--lime); border-left: 2px solid var(--lime); --dx: -1; --dy: 1; }
+.gal-vf-br { bottom: 0; right: 0; border-bottom: 2px solid var(--lime); border-right: 2px solid var(--lime); --dx: 1; --dy: 1; }
+@keyframes gal-vf-lock {
+  from {
+    opacity: 0;
+    transform: translate(calc(var(--dx) * 26px), calc(var(--dy) * 26px));
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, 0);
+  }
+}
+
+/* rule-of-thirds grid — fades in once focus locks */
+.gal-vf-grid {
+  position: absolute;
+  inset: 10px;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(187, 223, 77, 0.35) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(187, 223, 77, 0.35) 1px, transparent 1px);
+  background-size: calc(100% / 3 + 0.5px) calc(100% / 3 + 0.5px);
+  background-position: -1px -1px;
+  opacity: 0;
+  animation: gal-grid-fade 0.9s ease 1.15s forwards;
+}
+@keyframes gal-grid-fade {
+  to { opacity: 0.3; }
+}
+
+/* roaming AF point — hunts across the frame, blinks when it locks */
+.gal-af {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--lime);
+  top: 24%;
+  left: 22%;
+  opacity: 0;
+  pointer-events: none;
+  animation: gal-af-roam 9s ease-in-out 1.8s infinite;
+}
+.gal-af::after {
+  content: "";
+  position: absolute;
+  inset: 50%;
+  width: 4px;
+  height: 4px;
+  margin: -2px 0 0 -2px;
+  background: var(--lime);
+}
+@keyframes gal-af-roam {
+  0% { top: 24%; left: 22%; opacity: 0; }
+  6% { opacity: 1; box-shadow: var(--glow-lime-sm); }
+  10% { opacity: 0.55; box-shadow: none; }
+  26% { top: 24%; left: 22%; }
+  38% { top: 58%; left: 68%; }
+  44% { opacity: 1; box-shadow: var(--glow-lime-sm); }
+  48% { opacity: 0.55; box-shadow: none; }
+  62% { top: 58%; left: 68%; }
+  76% { top: 30%; left: 55%; }
+  82% { opacity: 1; box-shadow: var(--glow-lime-sm); }
+  88% { opacity: 0.55; box-shadow: none; }
+  96% { top: 30%; left: 55%; opacity: 0; }
+  100% { top: 24%; left: 22%; opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gal-vf-grid {
+    animation: none;
+    opacity: 0.25;
+  }
+  .gal-af { animation: none; opacity: 0; }
+}
+
+/* EXIF readout under the tagline */
+.gal-exif {
+  margin: 0 0 4px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  color: var(--cyan);
+  opacity: 0.75;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gal-viewfinder,
+  .gal-title,
+  .gal-vf {
+    animation: none;
+  }
+}
+
+.gal-tagline {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 20px 0 26px;
+  font-family: var(--font-mono);
+  font-size: clamp(0.72rem, 2vw, 0.95rem);
+  letter-spacing: 0.35em;
+  color: var(--text-muted);
+}
+.gal-dot { color: var(--lime); }
+
+.gal-sub {
+  margin: 0 auto;
+  max-width: 560px;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+/* scroll cue */
+.gal-scroll-cue {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+.gal-scroll-cue span {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.3em;
+  color: var(--text-muted);
+}
+.gal-scroll-track {
+  width: 2px;
+  height: 30px;
+  background: var(--line-strong);
+  position: relative;
+  overflow: hidden;
+}
+.gal-scroll-dot {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 2px;
+  height: 10px;
+  background: var(--lime);
+  animation: gal-scroll-drop 1.8s ease-in-out infinite;
+}
+@keyframes gal-scroll-drop {
+  0% { top: -10px; opacity: 0; }
+  30% { opacity: 1; }
+  100% { top: 30px; opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gal-scroll-dot { animation: none; top: 10px; opacity: 1; }
+}
+
+/* ============================ BODY ============================ */
+/* transparent so the CircuitBG constellation keeps drifting behind */
+.gal-body {
+  position: relative;
+  z-index: 1;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: clamp(40px, 6vh, 70px) var(--gutter) 70px;
+}
+
+/* loading / error status lines */
+.gal-status {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  letter-spacing: 0.22em;
+  color: var(--text-muted);
+  text-align: center;
+  margin: 40px 0;
+}
+.gal-blink {
+  color: var(--lime);
+  animation: gal-blink 1s steps(2) infinite;
+}
+@keyframes gal-blink {
+  50% { opacity: 0; }
+}
+.gal-error { color: var(--magenta); }
 
 /* --- THE PACKED RECTANGLE GRID --- */
 .gallery-grid {
   display: grid;
   /* Columns are flexible but try to stay around 200px */
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  
+
   /* Fixed row height to ensure boxes lock together like Tetris */
-  grid-auto-rows: 200px; 
-  
+  grid-auto-rows: 200px;
+
   /* CRITICAL: 'dense' makes the browser fill gaps aggressively */
-  grid-auto-flow: dense; 
-  
-  gap: 15px;
-  padding: 20px;
-  
-  /* Optional: Background to show the 'container' shape explicitly */
-  /* background: rgba(0, 0, 0, 0.5); */
-  /* border-radius: 20px; */
+  grid-auto-flow: dense;
+
+  gap: 14px;
 }
 
 /* --- Item Shapes --- */
 .gallery-item {
   position: relative;
   overflow: hidden;
-  border-radius: 8px;
-  background-color: #111;
-  transition: transform 0.3s ease;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
   cursor: pointer;
+  transition: border-color 0.25s var(--ease-out), box-shadow 0.25s var(--ease-out);
 }
 
 .gallery-img {
   width: 100%;
   height: 100%;
   object-fit: cover; /* Ensures image fills the assigned block perfectly */
-  transition: transform 0.5s ease;
+  transition: transform 0.5s var(--ease-out), filter 0.3s var(--ease-out);
 }
 
 /* -- Size Classes -- */
-/* 1x1 Square */
-.item-small {
-  grid-column: span 1;
-  grid-row: span 1;
-}
+.item-small { grid-column: span 1; grid-row: span 1; } /* 1x1 square */
+.item-wide  { grid-column: span 2; grid-row: span 1; } /* 2x1 landscape */
+.item-tall  { grid-column: span 1; grid-row: span 2; } /* 1x2 portrait */
+.item-big   { grid-column: span 2; grid-row: span 2; } /* 2x2 block */
 
-/* 2x1 Wide Landscape */
-.item-wide {
-  grid-column: span 2;
-  grid-row: span 1;
-}
-
-/* 1x2 Tall Portrait */
-.item-tall {
-  grid-column: span 1;
-  grid-row: span 2;
-}
-
-/* 2x2 Big Block */
-.item-big {
-  grid-column: span 2;
-  grid-row: span 2;
-}
-
-/* --- Hover Effects --- */
+/* --- Hover: HUD target-lock --- */
+/* NOTE: no transform on the container — framer-motion leaves an inline
+   `transform` on it after the reveal, which would override any CSS
+   hover transform. The zoom lives on the img instead. */
 .gallery-item:hover {
   z-index: 5;
-  transform: scale(1.05);
-  box-shadow: 0 10px 25px rgba(187, 223, 77, 0.4);
-  border: 2px solid #BBDF4D;
+  border-color: var(--lime);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55), var(--glow-lime-md);
 }
 
 .gallery-item:hover .gallery-img {
-  transform: scale(1.1);
+  transform: scale(1.08);
 }
 
+/* overlay: scanlines + tint, revealed on hover */
 .gallery-overlay {
   position: absolute;
-  top: 0; left: 0; width: 100%; height: 100%;
-  background: rgba(187, 223, 77, 0);
-  transition: background 0.3s ease;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0px,
+      rgba(0, 0, 0, 0) 3px,
+      rgba(0, 0, 0, 0.18) 4px
+    ),
+    rgba(187, 223, 77, 0.1);
+  opacity: 0;
+  transition: opacity 0.25s var(--ease-out);
   pointer-events: none;
 }
 .gallery-item:hover .gallery-overlay {
-  background: rgba(187, 223, 77, 0.15);
+  opacity: 1;
+}
+
+/* corner reticles appear with the overlay */
+.gallery-overlay::before,
+.gallery-overlay::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+}
+.gallery-overlay::before {
+  top: 7px;
+  left: 7px;
+  border-top: 2px solid var(--lime);
+  border-left: 2px solid var(--lime);
+}
+.gallery-overlay::after {
+  bottom: 7px;
+  right: 7px;
+  border-bottom: 2px solid var(--cyan);
+  border-right: 2px solid var(--cyan);
+}
+
+/* video play chip — angular lime tag, same language as ch-btn */
+.play-chip {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  color: var(--text-on-accent);
+  background: var(--lime);
+  padding: 8px 16px;
+  clip-path: polygon(8px 0, 100% 0, 100% calc(100% - 8px), calc(100% - 8px) 100%, 0 100%, 0 8px);
+  box-shadow: var(--glow-lime-sm);
+}
+
+/* videos advertise themselves even before hover */
+.gallery-item:has(.play-chip)::after {
+  content: "▶";
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-size: 0.7rem;
+  color: var(--lime);
+  text-shadow: 0 0 8px rgba(187, 223, 77, 0.8);
+  pointer-events: none;
+}
+.gallery-item:hover:has(.play-chip)::after {
+  opacity: 0;
 }
 
 /* --- Mobile --- */
 @media (max-width: 768px) {
+  .gal-hero { min-height: 48vh; padding: 70px 16px 56px; }
+  .gal-hud { display: none; }
+
   .gallery-grid {
     grid-template-columns: repeat(2, 1fr); /* Force 2 columns */
     grid-auto-rows: 150px;
-  }
-  
-  /* On mobile, reset big spans to keep it simple, or keep them if you like */
-  .item-big {
-    grid-column: span 2;
-    grid-row: span 2;
+    gap: 10px;
   }
 }

--- a/src/Components/Gallery.js
+++ b/src/Components/Gallery.js
@@ -1,17 +1,41 @@
 import React, { useEffect, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import ScrollHUD from './cyber/ScrollHUD';
+import Reveal from './cyber/Reveal';
+import Cursor from './cyber/Cursor';
 import './Gallery.css';
 
 // ==========================================
 // YOUR KEYS
 // ==========================================
-const API_KEY = 'AIzaSyAGU_45FCNsh5M6tuc9mnUqQ8Uhf5Cdjgk'; 
+const API_KEY = 'AIzaSyAGU_45FCNsh5M6tuc9mnUqQ8Uhf5Cdjgk';
 const FOLDER_ID = '1SDMIBSuweTO3zHHKqZXy7nMpEMPhVOK9';
 // ==========================================
 
+/* camera-style running timecode for the REC indicator */
+const RecTimecode = () => {
+  const reduce = useReducedMotion();
+  const [t, setT] = useState(0);
+
+  useEffect(() => {
+    if (reduce) return undefined;
+    const id = setInterval(() => {
+      if (!document.hidden) setT((v) => v + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [reduce]);
+
+  const pad = (n) => String(n).padStart(2, '0');
+  return (
+    <>{`${pad(Math.floor(t / 3600))}:${pad(Math.floor(t / 60) % 60)}:${pad(t % 60)}`}</>
+  );
+};
+
 const Gallery = () => {
-  const [items, setItems] = useState([]); // Renamed from 'images' to 'items'
+  const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const reduce = useReducedMotion();
 
   // Helper: Fisher-Yates Shuffle
   const shuffleArray = (array) => {
@@ -28,10 +52,10 @@ const Gallery = () => {
   useEffect(() => {
     const fetchMediaFromDrive = async () => {
       try {
-        // CHANGED: Query now asks for images OR videos
+        // Query asks for images OR videos
         const query = `'${FOLDER_ID}' in parents and trashed = false and (mimeType contains 'image/' or mimeType contains 'video/')`;
-        
-        // CHANGED: We request 'videoMediaMetadata' too
+
+        // We request 'videoMediaMetadata' too
         const url = `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name,mimeType,imageMediaMetadata,videoMediaMetadata)&key=${API_KEY}`;
 
         const response = await fetch(url);
@@ -41,22 +65,22 @@ const Gallery = () => {
 
         const processedItems = data.files.map(file => {
           const isVideo = file.mimeType.startsWith('video');
-          
+
           // Get metadata from the correct property
           const metadata = isVideo ? file.videoMediaMetadata : file.imageMediaMetadata;
-          
+
           // Fallback if metadata is missing (sometimes happens with new files)
           const width = metadata ? metadata.width : 1;
           const height = metadata ? metadata.height : 1;
           const aspectRatio = width / height;
-          
+
           // INTELLIGENT SIZING LOGIC
-          let sizeClass = 'item-small'; 
-          
+          let sizeClass = 'item-small';
+
           if (aspectRatio < 0.75) {
             sizeClass = 'item-tall'; // Portrait
           } else if (aspectRatio > 1.3) {
-             sizeClass = 'item-wide'; // Landscape
+            sizeClass = 'item-wide'; // Landscape
           } else if (width > 1200 && height > 1200) {
             sizeClass = 'item-big';  // High-res Square
           }
@@ -87,48 +111,119 @@ const Gallery = () => {
     fetchMediaFromDrive();
   }, []);
 
-  if (error) {
-    return (
-      <div className="gallery-container">
-        <div className="gallery-bg" />
-        <div className="gallery-content">
-          <h1 className="gallery-title">Gallery</h1>
-          <p className="error-message">Error: {error}</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="gallery-container">
-      <div className="gallery-bg" />
-      <div className="gallery-content">
-        <h1 className="gallery-title">Gallery</h1>
-        
-        {loading && <p>Loading memories...</p>}
+    <div className="gal-root">
+      {/* same neon dot + lagging ring cursor used on the other pages */}
+      <Cursor />
 
-        {!loading && (
+      <ScrollHUD
+        sections={[
+          { id: "gal-hero", code: "00", label: "VIEWFINDER" },
+          { id: "gal-body", code: "01", label: "ARCHIVE" },
+        ]}
+      />
+
+      <section className="gal-hero" id="gal-hero">
+        {/* moving square grid — same rhythm as the Articles/Components heroes */}
+        <div className="gal-grid-overlay" aria-hidden="true" />
+        <div className="gal-scanlines" aria-hidden="true" />
+        <div className="gal-vignette" aria-hidden="true" />
+        {/* one-shot camera flash on load */}
+        <div className="gal-flash" aria-hidden="true" />
+
+        <span className="gal-hud gal-hud-rec">
+          <i className="gal-rec-dot" aria-hidden="true" /> REC <RecTimecode />
+        </span>
+        <span className="gal-hud gal-hud-tr">VISUAL_LOG · ARCHIVE</span>
+
+        <div className="gal-hero-content">
+          <Reveal delay={0} y={16}>
+            <p className="gal-eyebrow">&gt; DECODING_VISUAL_ARCHIVE</p>
+          </Reveal>
+
+          {/* viewfinder: focus brackets lock onto the title as it
+             pulls focus (blur → sharp) */}
+          <div className="gal-viewfinder">
+            <span className="gal-vf gal-vf-tl" aria-hidden="true" />
+            <span className="gal-vf gal-vf-tr" aria-hidden="true" />
+            <span className="gal-vf gal-vf-bl" aria-hidden="true" />
+            <span className="gal-vf gal-vf-br" aria-hidden="true" />
+            {/* rule-of-thirds grid + roaming AF point, like a live camera */}
+            <span className="gal-vf-grid" aria-hidden="true" />
+            <span className="gal-af" aria-hidden="true" />
+            <h1 className="gal-title">GALLERY</h1>
+          </div>
+
+          <Reveal delay={0.25} y={16}>
+            <p className="gal-tagline">
+              <span>MOMENTS</span>
+              <span className="gal-dot">·</span>
+              <span>BUILDS</span>
+              <span className="gal-dot">·</span>
+              <span>PEOPLE</span>
+            </p>
+          </Reveal>
+
+          <Reveal delay={0.35} y={12}>
+            <p className="gal-exif">ISO 800 · ƒ/1.8 · 1/250 · AF-LOCK</p>
+          </Reveal>
+
+          <Reveal delay={0.45} y={16}>
+            <p className="gal-sub">
+              Snapshots from workshops, competitions, and everything the club
+              gets its hands on. Click a video tile to play it.
+            </p>
+          </Reveal>
+        </div>
+
+        <div className="gal-scroll-cue" aria-hidden="true">
+          <span>SCROLL</span>
+          <div className="gal-scroll-track">
+            <div className="gal-scroll-dot" />
+          </div>
+        </div>
+      </section>
+
+      <div className="gal-body" id="gal-body">
+        {loading && (
+          <p className="gal-status">
+            &gt; LOADING_MEMORY_BANKS <span className="gal-blink">▮</span>
+          </p>
+        )}
+
+        {error && (
+          <p className="gal-status gal-error">&gt; TRANSMISSION_FAILED :: {error}</p>
+        )}
+
+        {!loading && !error && (
           <div className="gallery-grid">
-            {items.map(item => (
-              <div 
-                key={item.id} 
+            {items.map((item, index) => (
+              <motion.div
+                key={item.id}
                 className={`gallery-item ${item.sizeClass}`}
-                // If it's a video, clicking opens it. If image, it does nothing (or you can add lightbox)
+                initial={reduce ? false : { opacity: 0, y: 26 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-40px" }}
+                transition={{
+                  duration: 0.55,
+                  delay: (index % 5) * 0.06,
+                  ease: [0.22, 1, 0.36, 1],
+                }}
+                // If it's a video, clicking opens it. If image, it does nothing
                 onClick={() => item.isVideo && window.open(item.videoLink, '_blank')}
               >
-                <img 
-                  src={item.src} 
-                  alt={item.alt} 
-                  className="gallery-img" 
-                  loading="lazy" 
+                <img
+                  src={item.src}
+                  alt={item.alt}
+                  className="gallery-img"
+                  loading="lazy"
                 />
-                
-                {/* Visual Overlay */}
-                <div className="gallery-overlay">
-                  {/* Show Play Button text only if it's a video */}
-                  {item.isVideo && <span className="play-icon">▶</span>}
+
+                {/* hover scan overlay + corner reticles */}
+                <div className="gallery-overlay" aria-hidden="true">
+                  {item.isVideo && <span className="play-chip">▶ PLAY</span>}
                 </div>
-              </div>
+              </motion.div>
             ))}
           </div>
         )}


### PR DESCRIPTION
## What this does
Full rebuild of the Gallery page. The Drive API fetch, Fisher-Yates shuffle, and aspect-ratio tile sizing logic are preserved; everything visual is new.

- **Hero — a live camera viewfinder**: one-shot flash on load, the title pulls focus (blur → sharp with letter-spacing tightening), corner focus brackets fly in and lock on, a rule-of-thirds grid fades in, and a roaming AF point hunts across the frame, blinking with a glow at each lock. A blinking ● REC with a running timecode replaces the top-left HUD label, plus an ISO/aperture EXIF readout under the tagline. Moving square-grid backdrop.
- **Grid** — the dense "tetris" layout is retained (small/wide/tall/big spans, dense flow), restyled as dark angular tiles. Tiles stagger in on scroll (framer whileInView, diagonal wave). Hover is a HUD target-lock: lime border + glow, image zoom, scanline overlay, corner reticles. Video tiles show an angular lime ▶ PLAY chip and an always-visible ▶ marker; clicking opens the Drive video.
- ScrollHUD wired (VIEWFINDER / ARCHIVE).

## Review notes
Deliberate detail: no transform on the tile container on hover (framer leaves an inline transform that would override it) — the zoom lives on the img instead. All motion respects `prefers-reduced-motion`. Drive API key and folder id are unchanged.

---
**Series notes** (part of a 14-PR redesign, preview: https://eclub-beta.netlify.app): every PR touches a disjoint set of files, so they merge conflict-free in any order (recommended: 01 → 14). The site builds only once the whole series is in. Nothing deploys to the live site until `npm run deploy` is run after the series lands.